### PR TITLE
Remove smarttabs option from .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,6 @@
 	"immed": true,
 	"noarg": true,
 	"quotmark": "single",
-	"smarttabs": true,
 	"trailing": true,
 	"undef": true,
 	"unused": true,


### PR DESCRIPTION
Remove `smarttabs` option from `.jshintrc`, as per the change in WP core.
