### PR TITLE
Add support for JSCS and wordpress preset

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+	"preset": "wordpress"
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,8 @@
 {
-	"preset": "wordpress"
+	"preset": "wordpress",
+	"excludeFiles": [
+		"**/vendor/**",
+		"**.min.js",
+		"**/node_modules/**"
+	]
 }

--- a/pre-commit
+++ b/pre-commit
@@ -32,6 +32,10 @@ WPCS_GITHUB_SRC=WordPress-Coding-Standards/WordPress-Coding-Standards
 WPCS_GIT_TREE=master
 PHPCS_FILE=$( upsearch phpcs.ruleset.xml )
 WPCS_STANDARD=$(if [ ! -z "$PHPCS_FILE" ]; then echo "$PHPCS_FILE"; else echo WordPress-Core; fi)
+JSCS_CONFIG="$( upsearch .jscsrc )"
+if [ -z "$JSCS_CONFIG" ]; then
+	JSCS_CONFIG="$( upsearch .jscs.json )"
+fi
 PATH_INCLUDES=./
 ENV_FILE=$( upsearch .ci-env.sh )
 if [ ! -z "$ENV_FILE" ]; then
@@ -66,7 +70,7 @@ if [ ${#STAGED_JS_FILES[@]} != 0 ]; then
 	fi
 
 	# JSHint
-	echo "## jshint"
+	echo "## JSHint"
 	if command -v jshint >/dev/null 2>&1; then
 		jshintignorepath=$( upsearch .jshintignore )
 		jshint $( if [ -n "$jshintignorepath" ]; then echo "--exclude-path $jshintignorepath"; fi ) "${STAGED_JS_FILES[@]}"
@@ -74,13 +78,14 @@ if [ ${#STAGED_JS_FILES[@]} != 0 ]; then
 		echo "Skipping jshint since not installed"
 	fi
 
-	# jscs
-	echo "## jslint"
-	if command -v jshint >/dev/null 2>&1; then
-		jshintignorepath=$( upsearch .jshintignore )
-		echo jshint $( if [ -n "$jshintignorepath" ]; then echo "--exclude-path $jshintignorepath"; fi ) "${STAGED_JS_FILES[@]}"
-	else
-		echo "Skipping jshint since not installed"
+	# JSCS
+	if [ -n "$JSCS_CONFIG" ]; then
+		echo "## JSCS"
+		if command -v jscs >/dev/null 2>&1; then
+			jscs --config="$JSCS_CONFIG" "${STAGED_JS_FILES[@]}"
+		else
+			echo "Skipping JSCS since not installed"
+		fi
 	fi
 
 fi

--- a/pre-commit
+++ b/pre-commit
@@ -82,7 +82,7 @@ if [ ${#STAGED_JS_FILES[@]} != 0 ]; then
 	if [ -n "$JSCS_CONFIG" ]; then
 		echo "## JSCS"
 		if command -v jscs >/dev/null 2>&1; then
-			jscs --config="$JSCS_CONFIG" "${STAGED_JS_FILES[@]}"
+			jscs --verbose --config="$JSCS_CONFIG" "${STAGED_JS_FILES[@]}"
 		else
 			echo "Skipping JSCS since not installed"
 		fi

--- a/pre-commit
+++ b/pre-commit
@@ -74,6 +74,15 @@ if [ ${#STAGED_JS_FILES[@]} != 0 ]; then
 		echo "Skipping jshint since not installed"
 	fi
 
+	# jscs
+	echo "## jslint"
+	if command -v jshint >/dev/null 2>&1; then
+		jshintignorepath=$( upsearch .jshintignore )
+		echo jshint $( if [ -n "$jshintignorepath" ]; then echo "--exclude-path $jshintignorepath"; fi ) "${STAGED_JS_FILES[@]}"
+	else
+		echo "Skipping jshint since not installed"
+	fi
+
 fi
 
 # Check for staged PHP files

--- a/pre-commit
+++ b/pre-commit
@@ -66,10 +66,10 @@ if [ ${#STAGED_JS_FILES[@]} != 0 ]; then
 	fi
 
 	# JSHint
-	echo "## jslint"
+	echo "## jshint"
 	if command -v jshint >/dev/null 2>&1; then
 		jshintignorepath=$( upsearch .jshintignore )
-		echo jshint $( if [ -n "$jshintignorepath" ]; then echo "--exclude-path $jshintignorepath"; fi ) "${STAGED_JS_FILES[@]}"
+		jshint $( if [ -n "$jshintignorepath" ]; then echo "--exclude-path $jshintignorepath"; fi ) "${STAGED_JS_FILES[@]}"
 	else
 		echo "Skipping jshint since not installed"
 	fi

--- a/readme.md
+++ b/readme.md
@@ -59,12 +59,13 @@ This will greatly speed up the time build time, giving you quicker feedback on y
 
 ## Symlinks
 
-Next, after configuring your `.travis.yml`, symlink the [`.jshintrc`](.jshint), [`.jshintignore`](.jshintignore), and (especially optionally) [`phpcs.ruleset.xml`](phpcs.ruleset.xml):
+Next, after configuring your `.travis.yml`, symlink the [`.jshintrc`](.jshint), [`.jshintignore`](.jshintignore), [`.jscsrc`](.jscsrc), and (especially optionally) [`phpcs.ruleset.xml`](phpcs.ruleset.xml):
 
 ```bash
 ln -s dev-lib/phpunit-plugin.xml . && git add phpunit.xml.dist # (if working with a plugin)
 ln -s dev-lib/.jshintrc . && git add .jshintrc
 ln -s dev-lib/.jshintignore . && git add .jshintignore
+ln -s dev-lib/.jscsrc . && git add .jscsrc
 ```
 
 ## PHPUnit Code Coverage

--- a/travis.before_script.sh
+++ b/travis.before_script.sh
@@ -18,6 +18,10 @@ export YUI_COMPRESSOR_CHECK=1
 export DISALLOW_EXECUTE_BIT=0
 export PATH_INCLUDES=./
 export WPCS_STANDARD=$(if [ -e phpcs.ruleset.xml ]; then echo phpcs.ruleset.xml; else echo WordPress-Core; fi)
+export JSCS_CONFIG="$( upsearch .jscsrc )"
+if [ -z "$JSCS_CONFIG" ]; then
+	export JSCS_CONFIG="$( upsearch .jscs.json )"
+fi
 
 # Load a .ci-env.sh to override the above environment variables
 if [ -e .ci-env.sh ]; then
@@ -49,6 +53,11 @@ $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR
 # Install JSHint
 if ! command -v jshint >/dev/null 2>&1; then
 	npm install -g jshint
+fi
+
+# Install jscs
+if ! command -v jscs >/dev/null 2>&1; then
+	npm install -g jscs
 fi
 
 # Install Composer

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -8,6 +8,9 @@ find $PATH_INCLUDES -path ./bin -prune -o \( -name '*.php' \) -exec php -lf {} \
 # Run JSHint
 jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) $(find $PATH_INCLUDES -name '*.js')
 
+# Run JSCS
+jscs --config="$JSCS_CONFIG"  $(find $PATH_INCLUDES -name '*.js')
+
 # Run PHP_CodeSniffer
 $PHPCS_DIR/scripts/phpcs --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi) $(find $PATH_INCLUDES -name '*.php')
 

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -9,7 +9,7 @@ find $PATH_INCLUDES -path ./bin -prune -o \( -name '*.php' \) -exec php -lf {} \
 jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) $(find $PATH_INCLUDES -name '*.js')
 
 # Run JSCS
-jscs --config="$JSCS_CONFIG"  $(find $PATH_INCLUDES -name '*.js')
+jscs --verbose --config="$JSCS_CONFIG"  $(find $PATH_INCLUDES -name '*.js')
 
 # Run PHP_CodeSniffer
 $PHPCS_DIR/scripts/phpcs --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi) $(find $PATH_INCLUDES -name '*.php')


### PR DESCRIPTION
Fixes #38 

Install JSCS:

```bash
npm install jscs -g
```

PhpStorm configuration:

![phpstorm-config](https://cloud.githubusercontent.com/assets/134745/6931255/c9e28082-d7bf-11e4-95ea-b97925255f79.png)

