### PR TITLE
Adding support for Gitter badges in README markdown

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -4,6 +4,4 @@ readme.md
 .ci-env.sh
 .gitmodules
 .travis.yml
-.coveralls.yml
-.gitter
 .git

--- a/.svnignore
+++ b/.svnignore
@@ -4,4 +4,6 @@ readme.md
 .ci-env.sh
 .gitmodules
 .travis.yml
+.coveralls.yml
+.gitter
 .git

--- a/class-wordpress-readme-parser.php
+++ b/class-wordpress-readme-parser.php
@@ -184,10 +184,13 @@ class WordPress_Readme_Parser {
 		if ( isset( $params['travis_ci_url'] ) || isset( $params['coveralls_url'] ) ) {
 			$markdown .= "\n";
 			if ( isset( $params['travis_ci_url'] ) ) {
-				$markdown .= sprintf( '[![Build Status](%s.png?branch=master)](%s) ', $params['travis_ci_url'], $params['travis_ci_url'] );
+				$markdown .= sprintf( '[![Build Status](%1$s.png?branch=master)](%1$s) ', $params['travis_ci_url'] );
 			}
 			if ( isset( $params['coveralls_url'] ) ) {
 				$markdown .= sprintf( '[![Build Status](%s?branch=master)](%s) ', $params['coveralls_badge_src'], $params['coveralls_url'] );
+			}
+			if ( isset( $params['gitter_url'] ) ) {
+				$markdown .= sprintf( '[![Join the chat at %1$s](https://badges.gitter.im/Join%20Chat.svg)](%1$s) ', $params['gitter_url'] );
 			}
 			$markdown .= "\n";
 		}

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -67,6 +67,9 @@ try {
 			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.png";
 			$md_args['coveralls_url'] = "https://coveralls.io/r/$github_account_repo";
 		}
+		if ( file_exists( $readme_root . '/.gitter' ) ) {
+			$md_args['gitter_url'] = "https://gitter.im/$github_account_repo";
+		}
 	}
 	$markdown = $readme->to_markdown( $md_args );
 

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,11 @@ You can generate your first test, saved to `tests/acceptance/WelcomeCept.php` by
 php /tmp/codecept.phar generate:cept acceptance Welcome
 ```
 
+## Gitter
+
+Create an empty `.gitter` file in the root of your repo and a [Gitter](https://gitter.im) chat badge will be added to your project's README.
+
+[![Join the chat](https://badges.gitter.im/Join%20Chat.svg)](#)
 
 ## Pre-commit Hook
 

--- a/svn-push
+++ b/svn-push
@@ -120,6 +120,8 @@ rsync -avz --delete --delete-excluded \
 	--exclude '/.jshint*' \
 	--exclude '/svn-url' \
 	--exclude '/.travis.yml' \
+	--exclude '/.coveralls.yml' \
+	--exclude '/.gitter' \
 	--exclude 'phpunit.xml*' \
 	$git_tmp_repo_dir/ $svn_tmp_repo_dir/trunk/
 if [ -e $git_tmp_repo_dir/assets/ ]; then


### PR DESCRIPTION
I wanted to add support for the Gitter repo chat badge, and since their aren't any configurations to speak of, I just made an empty `.gitter` file in the project root serve as a flag.

![Join the chat](https://badges.gitter.im/Join%20Chat.svg)

On a related note, it seems like there should be a global `config.yml` or something to consolidate all the things, that's a separate issue from this, but maybe something worth thinking about?

Also I noticed that `coveralls.yml` wasn't being ignored/excluded and thought it probably should be. If that's an incorrect assumption I can remove those lines.

/cc @westonruter 