### PR TITLE
Match dirs recursively on *.min.js files

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -2,7 +2,7 @@
 	"preset": "wordpress",
 	"excludeFiles": [
 		"**/vendor/**",
-		"**.min.js",
+		"**/*.min.js",
 		"**/node_modules/**"
 	]
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,3 @@
 **/vendor/**
-**.min.js
+**/*.min.js
 **/node_modules/**


### PR DESCRIPTION
The current rules only matched the root directory, these changes will recursively match all `*.min.js` files in project subdirectories.

See also
https://github.com/gruntjs/grunt-contrib-jshint/issues/53
http://stackoverflow.com/questions/24150232/relative-path-wildcards-in-jshintignore-not-working