### PR TITLE
Only check modified files or patches in pull requests on Travis

### DIFF
--- a/filter-report-for-patch-ranges.php
+++ b/filter-report-for-patch-ranges.php
@@ -1,0 +1,66 @@
+<?php
+# Take unix/emacs reports as STDIN, such as:
+#   foo/js/bar.js:503:55: Missing radix parameter.
+# And takes a single argument pointing to the file containing the output
+# of parse-diff-ranges.php, such as:
+#   path/to/file.ext:123-456
+# And then echos the line from STDIN if the path (here, foo/js/bar.hs) exists
+# in the latter, and the line number (here 503) is among the ranges represented.
+# If there are any matches, this script will return an exit code 1.
+# If there are no matches, the script will return exit code 0.
+
+if ( empty( $argv[1] ) ) {
+	echo 'Missing argument for file containing output of parse-diff-ranges.php.';
+	exit( 2 );
+}
+if ( ! file_exists( $argv[1] ) ) {
+	echo 'Argument for file containing output of parse-diff-ranges.php does not exist.';
+	exit( 2 );
+}
+
+$matched_patch_count = 0;
+
+$parsed_diff_ranges = array();
+foreach ( explode( "\n", trim( file_get_contents( $argv[1] ) ) ) as $line ) {
+	if ( preg_match( '/^(?P<file_path>.+):(?P<start_line>\d+)-(?P<end_line>\d+)$/', $line, $matches ) ) {
+		$file_path = realpath( $matches['file_path'] );
+		if ( ! array_key_exists( $file_path, $parsed_diff_ranges ) ) {
+			$parsed_diff_ranges[ $file_path ] = array();
+		}
+		$parsed_diff_ranges[ $file_path ][] = array(
+			'start_line' => intval( $matches['start_line'] ),
+			'end_line' => intval( $matches['end_line'] ),
+		);
+	}
+}
+print_r( $parsed_diff_ranges );
+
+while ( $line = fgets( STDIN ) ) {
+	if ( ! preg_match( '#^(?P<file_path>.+):(?P<line_number>\d+):\d+:.+$$#', $line, $matches ) ) {
+		continue;
+	}
+	$file_path = realpath( $matches['file_path'] );
+	if ( ! array_key_exists( $file_path, $parsed_diff_ranges ) ) {
+		continue;
+	}
+	$line_number = intval( $matches['line_number'] );
+	$matched = false;
+	foreach ( $parsed_diff_ranges[ $file_path ] as $range ) {
+		if ( $line_number >= $range['start_line'] && $line_number <= $range['end_line'] ) {
+			$matched = true;
+			break;
+		}
+	}
+	if ( ! $matched ) {
+		continue;
+	}
+
+	$matched_patch_count += 1;
+	echo $line;
+}
+
+if ( $matched_patch_count > 0 ) {
+	exit( 1 );
+} else {
+	exit( 0 );
+}

--- a/filter-report-for-patch-ranges.php
+++ b/filter-report-for-patch-ranges.php
@@ -33,7 +33,6 @@ foreach ( explode( "\n", trim( file_get_contents( $argv[1] ) ) ) as $line ) {
 		);
 	}
 }
-print_r( $parsed_diff_ranges );
 
 while ( $line = fgets( STDIN ) ) {
 	if ( ! preg_match( '#^(?P<file_path>.+):(?P<line_number>\d+):\d+:.+$$#', $line, $matches ) ) {

--- a/parse-diff-ranges.php
+++ b/parse-diff-ranges.php
@@ -1,0 +1,26 @@
+<?php
+# Take input from `git diff --no-prefix --unified=0`
+# Outputs path/to/file.ext:123-456
+# Where 123 is the start line in a diff and 456 is the end line.
+# A line appears for each patch occuring in a file.
+
+$current_file = null;
+
+while ( $line = fgets( STDIN ) ) {
+	if ( preg_match( '#^\+\+\+ (?P<file_path>.+)#', $line, $matches ) ) {
+		$current_file = $matches['file_path'];
+		$file_ranges[ $current_file ] = array();
+		continue;
+	}
+	if ( empty( $current_file ) ) {
+		continue;
+	}
+	if ( preg_match( '#^@@ -(\d+)(?:,(\d+))? \+(?P<line_number>\d+)(?:,(?P<line_count>\d+))? @@#', $line, $matches ) ) {
+		if ( empty( $matches['line_count'] ) ) {
+			$matches['line_count'] = 0;
+		}
+		$start_line = intval( $matches['line_number'] );
+		$end_line = intval( $matches['line_number'] ) + intval( $matches['line_count'] );
+		echo "$current_file:$start_line-$end_line\n";
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,16 @@ env:
 
 This will greatly speed up the time build time, giving you quicker feedback on your Pull Request status, and prevent your Travis build queue from getting too backlogged.
 
+### Limiting scope of Travis CI checks
+
+A barrier of entry for adding Travis CI to an existing project is that may complaing—a lot—about issues in your codebase. To get passing builds you then have a major effort to clean up your codebase to make it conforming to PHP_CodeSniffer, JSHint, and other tools. This is not ideal and can be problematic in projects with a lot of activity since these changes will add lots of conflicts with others' pull requests.
+
+To get around this the barrier of entry for Travis CI, there is now an environment variable defined in [`travis.before_script.sh`](travis.before_script.sh): `LIMIT_TRAVIS_PR_CHECK_SCOPE`. By default its value is `files` which means that when a pull request is opened and Travis runs its checks on the PR, it will limit the checks only to the files that have been touched in the pull request. Additionally, you can override this in the `.ci-env.sh` to be `LIMIT_TRAVIS_PR_CHECK_SCOPE=patches` so that Travis will restrict its scope even more and _only fail a build if any issues are reported on the changed lines (patches) in a PR_ (only PHP_CodeSniffer and JSHint currently are supported for this).
+
+With `LIMIT_TRAVIS_PR_CHECK_SCOPE=files` and `LIMIT_TRAVIS_PR_CHECK_SCOPE=patches` available, it is much easier to integrate Travis CI checks on existing projects that may have a lot of unconforming legacy code. You can fix up a codebase incrementally file-by-file or line-by-line in the normal course of fixing bugs and adding new features.
+
+If you want to disable Travis from limiting its scope, you can just add `LIMIT_TRAVIS_PR_CHECK_SCOPE=off`.
+
 ## Symlinks
 
 Next, after configuring your `.travis.yml`, symlink the [`.jshintrc`](.jshint), [`.jshintignore`](.jshintignore), [`.jscsrc`](.jscsrc), and (especially optionally) [`phpcs.ruleset.xml`](phpcs.ruleset.xml):
@@ -124,6 +134,7 @@ export WPCS_STANDARD=WordPress-Extra
 export DISALLOW_EXECUTE_BIT=1
 export YUI_COMPRESSOR_CHECK=1
 export PATH_INCLUDES="docroot/wp-content/plugins/acme-* docroot/wp-content/themes/acme-*"
+export LIMIT_TRAVIS_PR_CHECK_SCOPE=patches
 ```
 
 The last one here `PATH_INCLUDES` is especially useful when the dev-lib is used in the context of an entire site, so you can target just the themes and plugins that you're responsible for. For *excludes*, you can specify a `PHPCS_IGNORE` var and override the `.jshintignore`, though it would be better to have a `PATH_EXCLUDES` as well.

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ This will greatly speed up the time build time, giving you quicker feedback on y
 
 ### Limiting scope of Travis CI checks
 
-A barrier of entry for adding Travis CI to an existing project is that may complaing—a lot—about issues in your codebase. To get passing builds you then have a major effort to clean up your codebase to make it conforming to PHP_CodeSniffer, JSHint, and other tools. This is not ideal and can be problematic in projects with a lot of activity since these changes will add lots of conflicts with others' pull requests.
+A barrier of entry for adding Travis CI to an existing project is that may complaining—a lot—about issues in your codebase. To get passing builds you then have a major effort to clean up your codebase to make it conforming to PHP_CodeSniffer, JSHint, and other tools. This is not ideal and can be problematic in projects with a lot of activity since these changes will add lots of conflicts with others' pull requests.
 
 To get around this the barrier of entry for Travis CI, there is now an environment variable defined in [`travis.before_script.sh`](travis.before_script.sh): `LIMIT_TRAVIS_PR_CHECK_SCOPE`. By default its value is `files` which means that when a pull request is opened and Travis runs its checks on the PR, it will limit the checks only to the files that have been touched in the pull request. Additionally, you can override this in the `.ci-env.sh` to be `LIMIT_TRAVIS_PR_CHECK_SCOPE=patches` so that Travis will restrict its scope even more and _only fail a build if any issues are reported on the changed lines (patches) in a PR_ (only PHP_CodeSniffer and JSHint currently are supported for this).
 

--- a/travis.before_script.sh
+++ b/travis.before_script.sh
@@ -16,6 +16,7 @@ export WPCS_GITHUB_SRC=WordPress-Coding-Standards/WordPress-Coding-Standards
 export WPCS_GIT_TREE=master
 export YUI_COMPRESSOR_CHECK=1
 export DISALLOW_EXECUTE_BIT=0
+export LIMIT_TRAVIS_PR_CHECK_SCOPE=1
 export PATH_INCLUDES=./
 export WPCS_STANDARD=$(if [ -e phpcs.ruleset.xml ]; then echo phpcs.ruleset.xml; else echo WordPress-Core; fi)
 if [ -e .jscsrc ]; then

--- a/travis.before_script.sh
+++ b/travis.before_script.sh
@@ -16,7 +16,7 @@ export WPCS_GITHUB_SRC=WordPress-Coding-Standards/WordPress-Coding-Standards
 export WPCS_GIT_TREE=master
 export YUI_COMPRESSOR_CHECK=1
 export DISALLOW_EXECUTE_BIT=0
-export LIMIT_TRAVIS_PR_CHECK_SCOPE=1
+export LIMIT_TRAVIS_PR_CHECK_SCOPE=patches
 export PATH_INCLUDES=./
 export WPCS_STANDARD=$(if [ -e phpcs.ruleset.xml ]; then echo phpcs.ruleset.xml; else echo WordPress-Core; fi)
 if [ -e .jscsrc ]; then

--- a/travis.before_script.sh
+++ b/travis.before_script.sh
@@ -16,7 +16,7 @@ export WPCS_GITHUB_SRC=WordPress-Coding-Standards/WordPress-Coding-Standards
 export WPCS_GIT_TREE=master
 export YUI_COMPRESSOR_CHECK=1
 export DISALLOW_EXECUTE_BIT=0
-export LIMIT_TRAVIS_PR_CHECK_SCOPE=patches
+export LIMIT_TRAVIS_PR_CHECK_SCOPE=files # when set to 'patches', limits reports to only lines changed; TRAVIS_PULL_REQUEST must not be 'false'
 export PATH_INCLUDES=./
 export WPCS_STANDARD=$(if [ -e phpcs.ruleset.xml ]; then echo phpcs.ruleset.xml; else echo WordPress-Core; fi)
 if [ -e .jscsrc ]; then

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -2,19 +2,45 @@
 
 set -e
 
+find $PATH_INCLUDES -name '*.js'  | sed 's:^\.//*::' | sort > /tmp/included-js-files
+find $PATH_INCLUDES -name '*.php' | sed 's:^\.//*::' | sort > /tmp/included-php-files
+
+if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == '1' ]; then
+	git diff --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.php$' | cat - | sort > /tmp/changed-php-files
+	git diff --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.js$' | cat - | sort > /tmp/changed-js-files
+
+	echo 'comm -12 /tmp/included-php-files /tmp/changed-php-files'
+	comm -12 /tmp/included-php-files /tmp/changed-php-files
+
+	comm -12 /tmp/included-php-files /tmp/changed-php-files > /tmp/checked-php-files
+	comm -12 /tmp/included-js-files /tmp/changed-js-files > /tmp/checked-js-files
+else
+	cp /tmp/included-js-files /tmp/checked-js-files
+	cp /tmp/included-php-files /tmp/checked-php-files
+fi
+
+echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
+echo "PHP Files to check:"
+cat /tmp/checked-php-files
+echo
+
+echo "JS Files to check:"
+cat /tmp/checked-js-files
+echo
+
 # Run PHP syntax check
-find $PATH_INCLUDES -path ./bin -prune -o \( -name '*.php' \) -exec php -lf {} \;
+cat /tmp/checked-php-files | xargs --no-run-if-empty php -lf
 
 # Run JSHint
-jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) $(find $PATH_INCLUDES -name '*.js')
+cat /tmp/checked-js-files | xargs --no-run-if-empty jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi )
 
 # Run JSCS
 if [ -n "$JSCS_CONFIG" ] && [ -e "$JSCS_CONFIG" ]; then
-	jscs --verbose --config="$JSCS_CONFIG"  $(find $PATH_INCLUDES -name '*.js')
+	cat /tmp/checked-js-files | xargs --no-run-if-empty jscs --verbose --config="$JSCS_CONFIG"
 fi
 
 # Run PHP_CodeSniffer
-$PHPCS_DIR/scripts/phpcs --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi) $(find $PATH_INCLUDES -name '*.php')
+cat /tmp/checked-php-files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi)
 
 # Run PHPUnit tests
 if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then
@@ -22,8 +48,8 @@ if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then
 fi
 
 # Run YUI Compressor Check
-if [ "$YUI_COMPRESSOR_CHECK" == 1 ] && 0 != $( find $PATH_INCLUDES -name '*.js' | wc -l ); then
+if [ "$YUI_COMPRESSOR_CHECK" == 1 ] && [ 0 != $( cat /tmp/checked-js-files | wc -l ) ]; then
 	YUI_COMPRESSOR_PATH=/tmp/yuicompressor-2.4.8.jar
 	wget -O "$YUI_COMPRESSOR_PATH" https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.jar
-	java -jar "$YUI_COMPRESSOR_PATH" -o /dev/null $( find $PATH_INCLUDES -name '*.js' ) 2>&1
+	cat /tmp/checked-js-files | xargs --no-run-if-empty java -jar "$YUI_COMPRESSOR_PATH" -o /dev/null 2>&1
 fi

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -2,42 +2,37 @@
 
 set -e
 
-find $PATH_INCLUDES -name '*.js'  | sed 's:^\.//*::' | sort > /tmp/included-js-files
-find $PATH_INCLUDES -name '*.php' | sed 's:^\.//*::' | sort > /tmp/included-php-files
+find $PATH_INCLUDES -type f | sed 's:^\.//*::' | sort > /tmp/included-files
 
 if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" != '0' ]; then
-	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.php$' | cat - | sort > /tmp/changed-php-files
-	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.js$' | cat - | sort > /tmp/changed-js-files
+	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | cat - | sort > /tmp/changed-files
 
-	comm -12 /tmp/included-php-files /tmp/changed-php-files > /tmp/checked-php-files
-	comm -12 /tmp/included-js-files /tmp/changed-js-files > /tmp/checked-js-files
+	comm -12 /tmp/included-files /tmp/changed-files > /tmp/checked-files
 else
-	cp /tmp/included-js-files /tmp/checked-js-files
-	cp /tmp/included-php-files /tmp/checked-php-files
+	cp /tmp/included-files /tmp/checked-files
 fi
 
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
-echo "PHP Files to check:"
-cat /tmp/checked-php-files
-echo
-
-echo "JS Files to check:"
-cat /tmp/checked-js-files
+echo "Files to check:"
+cat /tmp/checked-files
 echo
 
 # Run PHP syntax check
-cat /tmp/checked-php-files | xargs --no-run-if-empty php -lf
+cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty php -lf
 
 # Run JSHint
-cat /tmp/checked-js-files | xargs --no-run-if-empty jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi )
+# TODO: Restrict to lines changed
+cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi )
 
 # Run JSCS
 if [ -n "$JSCS_CONFIG" ] && [ -e "$JSCS_CONFIG" ]; then
-	cat /tmp/checked-js-files | xargs --no-run-if-empty jscs --verbose --config="$JSCS_CONFIG"
+	# TODO: Restrict to lines changed
+	cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jscs --verbose --config="$JSCS_CONFIG"
 fi
 
 # Run PHP_CodeSniffer
-cat /tmp/checked-php-files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi)
+# TODO: Restrict to lines changed
+cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi)
 
 # Run PHPUnit tests
 if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then
@@ -45,8 +40,8 @@ if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then
 fi
 
 # Run YUI Compressor Check
-if [ "$YUI_COMPRESSOR_CHECK" == 1 ] && [ 0 != $( cat /tmp/checked-js-files | wc -l ) ]; then
+if [ "$YUI_COMPRESSOR_CHECK" == 1 ] && [ 0 != $( cat /tmp/checked-files | grep '.js' | wc -l ) ]; then
 	YUI_COMPRESSOR_PATH=/tmp/yuicompressor-2.4.8.jar
 	wget -O "$YUI_COMPRESSOR_PATH" https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.jar
-	cat /tmp/checked-js-files | xargs --no-run-if-empty java -jar "$YUI_COMPRESSOR_PATH" -o /dev/null 2>&1
+	cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty java -jar "$YUI_COMPRESSOR_PATH" -o /dev/null 2>&1
 fi

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -44,7 +44,7 @@ if [ -n "$JSCS_CONFIG" ] && [ -e "$JSCS_CONFIG" ]; then
 fi
 
 # Run PHP_CodeSniffer
-if ! cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-full --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
+if ! cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
 	echo "Here are the problematic PHPCS files:"
 	if [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == 'patches' ]; then
 	# Note that filter-report-for-patch-ranges will exit 1 if any files and lines in the report match any files of /tmp/checked-files

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -2,14 +2,10 @@
 
 set -e
 
-find $PATH_INCLUDES -type f | sed 's:^\.//*::' | sort > /tmp/included-files
-
 if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" != '0' ]; then
-	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | cat - | sort > /tmp/changed-files
-
-	comm -12 /tmp/included-files /tmp/changed-files > /tmp/checked-files
+	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT -- $PATH_INCLUDES | cat - | sort > /tmp/checked-files
 else
-	cp /tmp/included-files /tmp/checked-files
+	find $PATH_INCLUDES -type f | sed 's:^\.//*::' | sort > /tmp/checked-files
 fi
 
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -8,6 +8,7 @@ else
 	find $PATH_INCLUDES -type f | sed 's:^\.//*::' > /tmp/checked-files
 fi
 
+echo "LIMIT_TRAVIS_PR_CHECK_SCOPE: $LIMIT_TRAVIS_PR_CHECK_SCOPE"
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
 echo "Files to check:"
 cat /tmp/checked-files
@@ -30,7 +31,7 @@ cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-i
 if ! cat /tmp/checked-files | remove_diff_range | filter_js_files | xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
 	if [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == 'patches' ]; then
 		# Note that filter-report-for-patch-ranges will exit 1 if any files and lines in the report match any files of /tmp/checked-files
-		echo "(Issues from patches)"
+		echo "(Issues from patch subsets)"
 		cat /tmp/jshint-report | php $DEV_LIB_PATH/filter-report-for-patch-ranges.php /tmp/checked-files
 	else
 		cat /tmp/jshint-report
@@ -46,13 +47,9 @@ fi
 
 # Run PHP_CodeSniffer
 if ! cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
-	echo "Here are the problematic PHPCS files:"
-	cat /tmp/phpcs-report
-	cat /tmp/checked-files
-
 	if [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == 'patches' ]; then
 		# Note that filter-report-for-patch-ranges will exit 1 if any files and lines in the report match any files of /tmp/checked-files
-		echo "(Issues from patches)"
+		echo "(Issues from patch subsets)"
 		cat /tmp/phpcs-report | php $DEV_LIB_PATH/filter-report-for-patch-ranges.php /tmp/checked-files
 	else
 		cat /tmp/phpcs-report

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -5,9 +5,9 @@ set -e
 find $PATH_INCLUDES -name '*.js'  | sed 's:^\.//*::' | sort > /tmp/included-js-files
 find $PATH_INCLUDES -name '*.php' | sed 's:^\.//*::' | sort > /tmp/included-php-files
 
-if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == '1' ]; then
-	git diff --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.php$' | cat - | sort > /tmp/changed-php-files
-	git diff --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.js$' | cat - | sort > /tmp/changed-js-files
+if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" != '0' ]; then
+	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.php$' | cat - | sort > /tmp/changed-php-files
+	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.js$' | cat - | sort > /tmp/changed-js-files
 
 	comm -12 /tmp/included-php-files /tmp/changed-php-files > /tmp/checked-php-files
 	comm -12 /tmp/included-js-files /tmp/changed-js-files > /tmp/checked-js-files

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -9,9 +9,6 @@ if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == 
 	git diff --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.php$' | cat - | sort > /tmp/changed-php-files
 	git diff --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT | grep -E '\.js$' | cat - | sort > /tmp/changed-js-files
 
-	echo 'comm -12 /tmp/included-php-files /tmp/changed-php-files'
-	comm -12 /tmp/included-php-files /tmp/changed-php-files
-
 	comm -12 /tmp/included-php-files /tmp/changed-php-files > /tmp/checked-php-files
 	comm -12 /tmp/included-js-files /tmp/changed-js-files > /tmp/checked-js-files
 else

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ "$TRAVIS_PULL_REQUEST" != 'false' ] && [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" != '0' ]; then
-	git diff --diff-filter=AM --name-only $TRAVIS_BRANCH...$TRAVIS_COMMIT -- $PATH_INCLUDES | cat - | sort > /tmp/checked-files
+	git diff --diff-filter=AM --no-prefix --unified=0 $TRAVIS_BRANCH...$TRAVIS_COMMIT -- $PATH_INCLUDES | php $DEV_LIB_PATH/parse-diff-ranges.php  > /tmp/checked-files
 else
-	find $PATH_INCLUDES -type f | sed 's:^\.//*::' | sort > /tmp/checked-files
+	find $PATH_INCLUDES -type f | sed 's:^\.//*::' > /tmp/checked-files
 fi
 
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
@@ -13,11 +13,21 @@ echo "Files to check:"
 cat /tmp/checked-files
 echo
 
+function remove_diff_range {
+	sed 's/:[0-9][0-9]*-[0-9][0-9]*$//' | sort | uniq
+}
+function filter_php_files {
+	 grep '.php'
+}
+function filter_js_files {
+	grep '.js'
+}
+
 # Run PHP syntax check
-cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty php -lf
+cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-if-empty php -lf
 
 # Run JSHint
-if ! cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
+if ! cat /tmp/checked-files | remove_diff_range | filter_js_files | xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
 	echo "Here are the problematic JSHINT files:"
 	cat /tmp/jshint-report
 fi
@@ -25,12 +35,12 @@ fi
 # Run JSCS
 if [ -n "$JSCS_CONFIG" ] && [ -e "$JSCS_CONFIG" ]; then
 	# TODO: Restrict to lines changed (need an emacs/unix reporter)
-	cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jscs --verbose --config="$JSCS_CONFIG"
+	cat /tmp/checked-files | remove_diff_range | filter_js_files | xargs --no-run-if-empty jscs --verbose --config="$JSCS_CONFIG"
 fi
 
 # Run PHP_CodeSniffer
 # TODO: Restrict to lines changed
-if ! cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-full --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
+if ! cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-full --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
 	echo "Here are the problematic PHPCS files:"
 	cat /tmp/phpcs-report
 fi
@@ -41,8 +51,8 @@ if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then
 fi
 
 # Run YUI Compressor Check
-if [ "$YUI_COMPRESSOR_CHECK" == 1 ] && [ 0 != $( cat /tmp/checked-files | grep '.js' | wc -l ) ]; then
+if [ "$YUI_COMPRESSOR_CHECK" == 1 ] && [ 0 != $( cat /tmp/checked-files | filter_js_files | wc -l ) ]; then
 	YUI_COMPRESSOR_PATH=/tmp/yuicompressor-2.4.8.jar
 	wget -O "$YUI_COMPRESSOR_PATH" https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.jar
-	cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty java -jar "$YUI_COMPRESSOR_PATH" -o /dev/null 2>&1
+	cat /tmp/checked-files | remove_diff_range | filter_js_files | xargs --no-run-if-empty java -jar "$YUI_COMPRESSOR_PATH" -o /dev/null 2>&1
 fi

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -21,7 +21,7 @@ echo
 cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty php -lf
 
 # Run JSHint
-if ! cat /tmp/checked-files | grep '.js' xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
+if ! cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
 	echo "Here are the problematic JSHINT files:"
 	cat /tmp/jshint-report
 fi

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -21,18 +21,23 @@ echo
 cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty php -lf
 
 # Run JSHint
-# TODO: Restrict to lines changed
-cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jshint $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi )
+if ! cat /tmp/checked-files | grep '.js' xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
+	echo "Here are the problematic JSHINT files:"
+	cat /tmp/jshint-report
+fi
 
 # Run JSCS
 if [ -n "$JSCS_CONFIG" ] && [ -e "$JSCS_CONFIG" ]; then
-	# TODO: Restrict to lines changed
+	# TODO: Restrict to lines changed (need an emacs/unix reporter)
 	cat /tmp/checked-files | grep '.js' | xargs --no-run-if-empty jscs --verbose --config="$JSCS_CONFIG"
 fi
 
 # Run PHP_CodeSniffer
 # TODO: Restrict to lines changed
-cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi)
+if ! cat /tmp/checked-files | grep '.php' | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-full --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
+	echo "Here are the problematic PHPCS files:"
+	cat /tmp/phpcs-report
+fi
 
 # Run PHPUnit tests
 if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -40,7 +40,7 @@ if [ -n "$JSCS_CONFIG" ] && [ -e "$JSCS_CONFIG" ]; then
 fi
 
 # Run PHP_CodeSniffer
-cat /tmp/checked-php-files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi)
+cat /tmp/checked-php-files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi)
 
 # Run PHPUnit tests
 if [ -e phpunit.xml ] || [ -e phpunit.xml.dist ]; then

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -30,6 +30,7 @@ cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-i
 if ! cat /tmp/checked-files | remove_diff_range | filter_js_files | xargs --no-run-if-empty jshint --reporter=unix $( if [ -e .jshintignore ]; then echo "--exclude-path .jshintignore"; fi ) > /tmp/jshint-report; then
 	if [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == 'patches' ]; then
 		# Note that filter-report-for-patch-ranges will exit 1 if any files and lines in the report match any files of /tmp/checked-files
+		echo "(Issues from patches)"
 		cat /tmp/jshint-report | php $DEV_LIB_PATH/filter-report-for-patch-ranges.php /tmp/checked-files
 	else
 		cat /tmp/jshint-report
@@ -46,8 +47,12 @@ fi
 # Run PHP_CodeSniffer
 if ! cat /tmp/checked-files | remove_diff_range | filter_php_files | xargs --no-run-if-empty $PHPCS_DIR/scripts/phpcs -s --report-emacs=/tmp/phpcs-report --standard=$WPCS_STANDARD $(if [ -n "$PHPCS_IGNORE" ]; then echo --ignore=$PHPCS_IGNORE; fi); then
 	echo "Here are the problematic PHPCS files:"
+	cat /tmp/phpcs-report
+	cat /tmp/checked-files
+
 	if [ "$LIMIT_TRAVIS_PR_CHECK_SCOPE" == 'patches' ]; then
-	# Note that filter-report-for-patch-ranges will exit 1 if any files and lines in the report match any files of /tmp/checked-files
+		# Note that filter-report-for-patch-ranges will exit 1 if any files and lines in the report match any files of /tmp/checked-files
+		echo "(Issues from patches)"
 		cat /tmp/phpcs-report | php $DEV_LIB_PATH/filter-report-for-patch-ranges.php /tmp/checked-files
 	else
 		cat /tmp/phpcs-report


### PR DESCRIPTION
With the `LIMIT_TRAVIS_PR_CHECK_SCOPE=files` environment variable set (on by default), the Travis script will restrict PHP_CodeSniffer, JSHint, and other checks to the files that have been modified in the scope of the PR.

This change makes it much much easier to get started with integrating Travis into the pull request workflow to have post-push code quality checks beyond the initial [`pre-commit` checks](https://github.com/xwp/wp-dev-lib/blob/master/pre-commit). Now coding standard issues can be resolved incrementally, file-by-file, instead of having to fix issues in the entire project at once to get a Travis :+1: 

Additionally, you can now add `LIMIT_TRAVIS_PR_CHECK_SCOPE=patches` to your `.ci-env.sh` or to your `before` section of your forked `.travis.yml` and _Travis will filter out any issues  that don't apply to the changes in the pull request._ What this means is that files can be incrementally cleaned up patch-by-patch, instead of having to clean the entire file to get a Travis build pass. :open_mouth: (This patch subset checking is only supported for JSHint and PHP_CodeSniffer currently.)

See also #77.