### PR TITLE
Prevent overriding WP_TESTS_DIR environment var if set

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -16,7 +16,9 @@ upsearch () {
 	done
 }
 
-WP_TESTS_DIR=/tmp/wordpress-tests/
+if [ -z "$WP_TESTS_DIR" ]; then
+	WP_TESTS_DIR=/tmp/wordpress-tests/
+fi
 
 YUI_COMPRESSOR_CHECK=1
 CODECEPTION_CHECK=1


### PR DESCRIPTION
This allows commits to be made inside of Vagrant without blowing away any `$WP_TESTS_DIR` environment variable.