### PR TITLE
Install composer with curl

### DIFF
--- a/travis.before_script.sh
+++ b/travis.before_script.sh
@@ -64,7 +64,7 @@ fi
 
 # Install Composer
 if [ -e composer.json ]; then
-	wget http://getcomposer.org/composer.phar && php composer.phar install --dev
+	curl -s http://getcomposer.org/installer | php && php composer.phar install
 fi
 
 set +e


### PR DESCRIPTION
PHP 5.2 fails to install Composer using `wget`, and all versions appear to work when you use `curl`.