### PR TITLE
#112 Added support for antecedent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 codecept.phar
+lib/antecedent/patchwork/cache/

--- a/lib/antecedent/patchwork/LICENSE
+++ b/lib/antecedent/patchwork/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010-2014 Ignas Rudaitis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/antecedent/patchwork/Patchwork.php
+++ b/lib/antecedent/patchwork/Patchwork.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork;
+
+require_once __DIR__ . "/src/Exceptions.php";
+require_once __DIR__ . "/src/Interceptor.php";
+require_once __DIR__ . "/src/Preprocessor.php";
+require_once __DIR__ . "/src/Utils.php";
+require_once __DIR__ . "/src/Stack.php";
+
+function replace($original, $replacement)
+{
+    return Interceptor\patch($original, $replacement);
+}
+
+/**
+ * @deprecated
+ * @alias replace
+ */
+function replaceLater($function, $replacement)
+{
+    return replace($function, $replacement);
+}
+
+function fallBack()
+{
+    throw new Exceptions\NoResult;
+}
+
+/**
+ * @alias fallBack
+ */
+function pass()
+{
+    fallBack();
+}
+
+function callOriginal(array $args = null)
+{
+    return Interceptor\callOriginal($args);
+}
+
+function undo(Interceptor\PatchHandle $handle)
+{
+    $handle->removePatches();
+}
+
+function undoAll()
+{
+    Interceptor\unpatchAll();
+}
+
+function silence(Interceptor\PatchHandle $handle)
+{
+    $handle->silence();
+}
+
+function enableCaching($location, $assertWritable = true)
+{
+    Preprocessor\setCacheLocation($location, $assertWritable);
+}
+
+function blacklist($path)
+{
+    Preprocessor\exclude($path);
+}
+
+if (Utils\runningOnHHVM()) {
+    # no preprocessor needed on HHVM;
+    # just let Patchwork become a wrapper for fb_intercept()
+    spl_autoload_register('Patchwork\Interceptor\deployQueue');
+    register_shutdown_function('Patchwork\undoAll');
+    return;
+}
+
+enableCaching(__DIR__ . '/cache', false);
+
+Preprocessor\Stream::wrap();
+
+Preprocessor\attach(array(
+    Preprocessor\Callbacks\Preprocessor\propagateThroughEval(),
+    Preprocessor\Callbacks\Interceptor\injectCallInterceptionCode(),
+    Preprocessor\Callbacks\Interceptor\injectQueueDeploymentCode(),
+));
+
+Preprocessor\onImport(array(
+    Preprocessor\Callbacks\Interceptor\markPreprocessedFiles(),
+));
+
+Utils\clearOpcodeCaches();

--- a/lib/antecedent/patchwork/README.md
+++ b/lib/antecedent/patchwork/README.md
@@ -1,0 +1,87 @@
+# Patchwork
+
+### Version 1.3.4
+
+A pure PHP library that lets you redefine user-defined functions at runtime. Released under the terms of the [MIT license](http://www.opensource.org/licenses/mit-license.php).
+
+## Functionality and Limitations
+
+In other words, Patchwork is a partial implementation of [`runkit_function_redefine`](http://php.net/runkit_function_redefine) in userland PHP 5.3 code.
+
+As of now, it only works with user-defined functions and methods, including static, final, and non-public ones.
+
+Internal function redefinition functionality is currently only offered by core PHP extensions: [Runkit](http://php.net/manual/en/book.runkit.php), [ext/test_helpers](https://github.com/sebastianbergmann/php-test-helpers), and
+[krakjoe/uopz](https://github.com/krakjoe/uopz).
+
+It is, however, planned and being developed for Patchwork's next major release.
+
+## Requirements
+
+Patchwork requires at least either Zend's PHP 5.3.0 or HHVM 3.2.0 to run. Compatibility with lower versions of HHVM is possible, but has not been tested.
+
+## Example
+
+All these steps occur at the same runtime:
+
+### 1. Define a function
+
+```php
+function size($x)
+{
+    return count($x);
+}
+
+size(array(1, 2)); # => 2
+```
+
+### 2. Replace its definition
+
+```php
+Patchwork\replace("size", function($x)
+{
+    return "huge";
+});
+
+size(array(1, 2)); # => "huge"
+```
+
+### 3. Undo the redefinition
+
+```php
+Patchwork\undoAll();
+
+size(array(1, 2)); # => 2
+```
+
+## Setup
+
+To make the above example actually run, a dummy entry script is needed, one that would would first import Patchwork, and then the rest of the application:
+
+```php
+require 'vendor/antecedent/patchwork/Patchwork.php';
+require 'actualEntryScript.php';
+```
+
+Variations on this setup are possible: see the [Setup](http://antecedent.github.io/patchwork/docs/setup.html) section of the documentation for details.
+
+For instance, PHPUnit users will most likely want to use a `--bootstrap vendor/antecedent/patchwork/Patchwork.php` command line option.
+
+## Installation using Composer
+
+A sample `composer.json` importing only Patchwork would be as follows:
+
+```json
+{
+    "require-dev": {
+        "antecedent/patchwork": "*"
+    }
+}
+```
+
+## Further Reading
+
+For more information, please refer to the online documentation, which can be accessed and navigated using the top menu of [Patchwork's website](http://antecedent.github.io/patchwork/).
+
+## Issues
+
+If you come across any bugs in Patchwork, please report them [here](https://github.com/antecedent/patchwork/issues). Thank you!

--- a/lib/antecedent/patchwork/composer.json
+++ b/lib/antecedent/patchwork/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "antecedent/patchwork",
+    "description": "A pure PHP library that lets you redefine user-defined functions at runtime.",
+    "keywords": ["testing", "redefinition", "runkit", "monkeypatching", "interception", "aop", "aspect"],
+    "homepage": "http://antecedent.github.io/patchwork/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Ignas Rudaitis",
+            "email": "ignas.rudaitis@gmail.com"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {
+        "php": ">=5.3.0"
+    }
+}

--- a/lib/antecedent/patchwork/src/Exceptions.php
+++ b/lib/antecedent/patchwork/src/Exceptions.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Exceptions;
+
+use Patchwork\Utils;
+
+abstract class Exception extends \Exception
+{
+}
+
+class NoResult extends Exception
+{
+}
+
+class StackEmpty extends Exception
+{
+    protected $message = "There are no calls in the dispatch stack";
+}
+
+abstract class CallbackException extends Exception
+{
+    function __construct($callback)
+    {
+        parent::__construct(sprintf($this->message, Utils\callbackToString($callback)));
+    }
+}
+
+class NotUserDefined extends CallbackException
+{
+    protected $message = "%s is not a user-defined function or method";
+}
+
+class DefinedTooEarly extends CallbackException
+{
+
+    function __construct($callback)
+    {
+        $this->message = "The file that defines %s was included earlier than Patchwork. " .
+                         "This is likely a result of an improper setup; see " .
+                         "http://antecedent.github.io/patchwork/docs/setup.html for details.";
+        parent::__construct($callback);
+    }
+}
+
+class CacheLocationUnavailable extends Exception
+{
+    public function __construct($location)
+    {
+        parent::__construct(sprintf(
+            "The specified cache location is inexistent or read-only: %s",
+            $location
+        ));
+    }
+}

--- a/lib/antecedent/patchwork/src/Interceptor.php
+++ b/lib/antecedent/patchwork/src/Interceptor.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Interceptor;
+
+require __DIR__ . "/Interceptor/PatchHandle.php";
+require __DIR__ . "/Interceptor/MethodPatchDecorator.php";
+
+use Patchwork\Utils;
+use Patchwork\Stack;
+use Patchwork\Exceptions;
+
+const EVALUATED_CODE_FILE_NAME_SUFFIX = "/\(\d+\) : eval\(\)'d code$/";
+
+function patch($function, $patch)
+{
+    assertPatchable($function);
+    list($class, $method) = Utils\interpretCallback($function);
+    if (empty($class)) {
+        $handle = patchFunction($method, $patch);
+    } else {
+        if (Utils\callbackTargetDefined($function)) {
+            $handle = patchMethod($function, $patch);
+        } else {
+            $handle = queueMethodPatch($function, $patch);
+            if (Utils\runningOnHHVM()) {
+                patchOnHHVM("$class::$method", $handle);
+            }
+        }
+    }
+    attachExistenceAssertion($handle, $function);
+    return $handle;
+}
+
+function attachExistenceAssertion(PatchHandle $handle, $target)
+{
+    $handle->addExpirationHandler(function() use ($target) {
+        if (!Utils\callbackTargetDefined($target)) {
+            # Not using exceptions because this might happen during PHP shutdown
+            $message = "%s was never defined during the lifetime of its redefinition";
+            trigger_error(sprintf($message, Utils\callbackToString($target)), E_USER_WARNING);
+        }
+    });
+}
+
+function assertPatchable($function)
+{
+    if (!Utils\callbackTargetDefined($function)) {
+        return;
+    }
+    $reflection = Utils\reflectCallback($function);
+    if ($reflection->isInternal()) {
+        throw new Exceptions\NotUserDefined($function);
+    }
+    $file = $reflection->getFileName();
+    if (Utils\runningOnHHVM()) {
+        return;
+    }
+    $evaluated = preg_match(EVALUATED_CODE_FILE_NAME_SUFFIX, $file);
+    if (!$evaluated && empty(State::$preprocessedFiles[$file])) {
+        throw new Exceptions\DefinedTooEarly($function);
+    }
+}
+
+function patchFunction($function, $patch)
+{
+    $handle = new PatchHandle;
+    $patches = &State::$patches[null][$function];
+    $offset = Utils\append($patches, array($patch, $handle));
+    $handle->addReference($patches[$offset]);
+    if (Utils\runningOnHHVM()) {
+        patchOnHHVM($function, $handle);
+    }
+    return $handle;
+}
+
+function queueMethodPatch($function, $patch)
+{
+    $handle = new PatchHandle;
+    $queuedPatch = array($function, $patch, $handle);
+    $offset = Utils\append(State::$queuedPatches, $queuedPatch);
+    $handle->addReference(State::$queuedPatches[$offset]);
+    return $handle;
+}
+
+function deployQueue()
+{
+    foreach (State::$queuedPatches as $offset => $queuedPatch) {
+        if (empty($queuedPatch)) {
+            unset(State::$queuedPatches[$offset]);
+            continue;
+        }
+        list($function, $patch, $handle) = $queuedPatch;
+        if (Utils\callbackTargetDefined($function)) {
+            assertPatchable($function, false);
+            patchMethod($function, $patch, $handle);
+            unset(State::$queuedPatches[$offset]);
+        }
+    }
+}
+
+function patchMethod($function, $patch, PatchHandle $handle = null)
+{
+    if ($handle === null) {
+        $handle = new PatchHandle;
+    }
+    list($class, $method, $instance) = Utils\interpretCallback($function);
+    $patch = new MethodPatchDecorator($patch);
+    $patch->superclass = $class;
+    $patch->method = $method;
+    $patch->instance = $instance;
+    $reflection = new \ReflectionMethod($class, $method);
+    $declaringClass = $reflection->getDeclaringClass();
+    $class = $declaringClass->getName();
+    if (!Utils\runningOnHHVM() && Utils\traitsSupported()) {
+        $aliases = $declaringClass->getTraitAliases();
+        if (isset($aliases[$method])) {
+            list($trait, $method) = explode("::", $aliases[$method]);
+        }
+    }
+    $patches = &State::$patches[$class][$method];
+    $offset = Utils\append($patches, array($patch, $handle));
+    $handle->addReference($patches[$offset]);
+    if (Utils\runningOnHHVM()) {
+        patchOnHHVM("$class::$method", $handle);
+    }
+    return $handle;
+}
+
+function unpatchAll()
+{
+    foreach (State::$patches as $class => $patchesByClass) {
+        foreach ($patchesByClass as $method => $patches) {
+            foreach ($patches as $patch) {
+                list($callback, $handle) = $patch;
+                $handle->removePatches();
+            }
+        }
+    }
+    State::$patches = array();
+}
+
+function runPatch($patch)
+{
+    return call_user_func_array($patch, Stack\top("args"));
+}
+
+function intercept($class, $calledClass, $method, $frame, &$result, array $args = null)
+{
+    $success = false;
+    Stack\pushFor($frame, $calledClass, function() use ($class, $method, &$result, &$success) {
+        foreach (getPatchesFor($class, $method) as $offset => $patch) {
+            if (empty($patch)) {
+                unset(State::$patches[$class][$method][$offset]);
+                continue;
+            }
+            State::$patchStack[] = array($class, $method, $offset);
+            try {
+                $result = runPatch(reset($patch));
+                $success = true;
+            } catch (Exceptions\NoResult $e) {
+                array_pop(State::$patchStack);
+                continue;
+            }
+            array_pop(State::$patchStack);
+        }
+    }, $args);
+    return $success;
+}
+
+function callOriginal(array $args = null)
+{
+    list($class, $method, $offset) = end(State::$patchStack);
+    $patch = &State::$patches[$class][$method][$offset];
+    $backup = $patch;
+    $patch = array('Patchwork\fallBack', new PatchHandle);
+    $top = Stack\top();
+    if ($args === null) {
+        $args = $top["args"];
+    }
+    try {
+        if (isset($top["class"])) {
+            $reflection = new \ReflectionMethod(Stack\topCalledClass(), $top["function"]);
+            $reflection->setAccessible(true);
+            $result = $reflection->invokeArgs(Stack\top("object"), $args);
+        } else {
+            $result = call_user_func_array($top["function"], $args);
+        }
+    } catch (\Exception $e) {
+        $exception = $e;
+    }
+    $patch = $backup;
+    if (isset($exception)) {
+        throw $exception;
+    }
+    return $result;
+}
+
+function patchOnHHVM($function, PatchHandle $handle)
+{
+    fb_intercept($function, function($name, $obj, $args, $data, &$done) {
+        deployQueue();
+        list($class, $method) = Utils\interpretCallback($name);
+        $calledClass = null;
+        if (is_string($obj)) {
+            $calledClass = $obj;
+        } elseif (is_object($obj)) {
+            $calledClass = get_class($obj);
+        }
+        $frame = count(debug_backtrace(false)) - 1;
+        $result = null;
+        $done = intercept($class, $calledClass, $method, $frame, $result, $args);
+        return $result;
+    });
+    $handle->addExpirationHandler(getHHVMExpirationHandler($function));
+}
+
+function getHHVMExpirationHandler($function)
+{
+    return function() use ($function) {
+        list($class, $method) = Utils\interpretCallback($function);
+        $empty = true;
+        foreach (getPatchesFor($class, $method) as $offset => $patch) {
+            if (!empty($patch)) {
+                $empty = false;
+                break;
+            } else {
+                unset(State::$patches[$class][$method][$offset]);
+            }
+        }
+        if ($empty) {
+            fb_intercept($function, null);
+        }
+    };
+}
+
+function getPatchesFor($class, $method)
+{
+    if (!isset(State::$patches[$class][$method])) {
+        return array();
+    }
+    return State::$patches[$class][$method];
+}
+
+class State
+{
+    static $patches = array();
+    static $queuedPatches = array();
+    static $preprocessedFiles = array();
+    static $patchStack = array();
+}

--- a/lib/antecedent/patchwork/src/Interceptor/MethodPatchDecorator.php
+++ b/lib/antecedent/patchwork/src/Interceptor/MethodPatchDecorator.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Interceptor;
+
+use Patchwork;
+use Patchwork\Stack;
+
+class MethodPatchDecorator
+{
+    public $superclass;
+    public $instance;
+    public $method;
+
+    private $patch;
+
+    public function __construct($patch)
+    {
+        $this->patch = $patch;
+    }
+
+    public function __invoke()
+    {
+        $top = Stack\top();
+        $superclassMatches = $this->superclassMatches();
+        $instanceMatches = $this->instanceMatches($top);
+        $methodMatches = $this->methodMatches($top);
+        if ($superclassMatches && $instanceMatches && $methodMatches) {
+            $patch = $this->patch;
+            if (is_callable(array($patch, "bindTo"))) {
+                if (isset($top["object"]) && $patch instanceof \Closure) {
+                    $patch = $patch->bindTo($top["object"], $this->superclass);
+                }
+            }
+            return runPatch($patch);
+        }
+        Patchwork\fallBack();
+    }
+
+    private function superclassMatches()
+    {
+        return $this->superclass === null ||
+               Stack\topCalledClass() === $this->superclass ||
+               is_subclass_of(Stack\topCalledClass(), $this->superclass);
+    }
+
+    private function instanceMatches(array $top)
+    {
+        return $this->instance === null ||
+               (isset($top["object"]) && $top["object"] === $this->instance);
+    }
+
+    private function methodMatches(array $top)
+    {
+        return $this->method === null ||
+               $top["function"] === $this->method;
+    }
+}

--- a/lib/antecedent/patchwork/src/Interceptor/PatchHandle.php
+++ b/lib/antecedent/patchwork/src/Interceptor/PatchHandle.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Interceptor;
+
+class PatchHandle
+{
+    private $references = array();
+    private $expirationHandlers = array();
+    private $silenced = false;
+
+    public function __destruct()
+    {
+        $this->removePatches();
+    }
+
+    public function addReference(&$reference)
+    {
+        $this->references[] = &$reference;
+    }
+
+    public function removePatches()
+    {
+        foreach ($this->references as &$reference) {
+            $reference = null;
+        }
+        if (!$this->silenced) {
+            foreach ($this->expirationHandlers as $expirationHandler) {
+                $expirationHandler();
+            }
+        }
+        $this->expirationHandlers = array();
+    }
+
+    public function addExpirationHandler($expirationHandler)
+    {
+        $this->expirationHandlers[] = $expirationHandler;
+    }
+
+    public function silence()
+    {
+        $this->silenced = true;
+    }
+}

--- a/lib/antecedent/patchwork/src/Preprocessor.php
+++ b/lib/antecedent/patchwork/src/Preprocessor.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Preprocessor;
+
+require __DIR__ . "/Preprocessor/Source.php";
+require __DIR__ . "/Preprocessor/Stream.php";
+require __DIR__ . "/Preprocessor/Callbacks/Generic.php";
+require __DIR__ . "/Preprocessor/Callbacks/Interceptor.php";
+require __DIR__ . "/Preprocessor/Callbacks/Preprocessor.php";
+
+use Patchwork\Exceptions;
+use Patchwork\Utils;
+
+const OUTPUT_DESTINATION = 'php://memory';
+const OUTPUT_ACCESS_MODE = 'rb+';
+
+function preprocess(Source $s)
+{
+    foreach (State::$callbacks as $callback) {
+        $callback($s);
+    }
+}
+
+function preprocessString($code)
+{
+    $source = new Source(token_get_all($code));
+    preprocess($source);
+    return (string) $source;
+}
+
+function preprocessForEval($code)
+{
+    $prefix = "<?php ";
+    return substr(preprocessString($prefix . $code), strlen($prefix));
+}
+
+function cacheEnabled()
+{
+    return State::$cacheLocation !== null;
+}
+
+function getCachedPath($file)
+{
+    return State::$cacheLocation . '/' . urlencode($file);
+}
+
+function availableCached($file)
+{
+    return cacheEnabled() &&
+           file_exists(getCachedPath($file)) &&
+           filemtime($file) <= filemtime(getCachedPath($file));
+}
+
+function preprocessAndOpen($file)
+{
+    foreach (State::$importListeners as $listener) {
+        $listener($file);
+    }
+    if (availableCached($file)) {
+        return fopen(getCachedPath($file), 'r');
+    }
+    $resource = fopen(OUTPUT_DESTINATION, OUTPUT_ACCESS_MODE);
+    $code = file_get_contents($file, true);
+    $source = new Source(token_get_all($code));
+    $source->file = $file;
+    preprocess($source);
+    if (cacheEnabled()) {
+        file_put_contents(getCachedPath($file), $source);
+        return preprocessAndOpen($file);
+    }
+    fwrite($resource, $source);
+    rewind($resource);
+    return $resource;
+}
+
+function shouldPreprocess($file)
+{
+    foreach (State::$blacklist as $path) {
+        if (strpos(Utils\normalizePath($file), $path) === 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function attach($callbacks)
+{
+    State::$callbacks = array_merge(State::$callbacks, (array) $callbacks);
+}
+
+function onImport($listeners)
+{
+    State::$importListeners = array_merge(State::$importListeners, (array) $listeners);
+}
+
+function exclude($path)
+{
+    State::$blacklist[] = Utils\normalizePath($path);
+}
+
+function setCacheLocation($location, $assertWritable = true)
+{
+    $location = Utils\normalizePath($location);
+    if (!is_writable($location)) {
+        if ($assertWritable) {
+            throw new Exceptions\CacheLocationUnavailable($location);
+        }
+        return false;
+    }
+    State::$cacheLocation = $location;
+    return true;
+}
+
+class State
+{
+    static $callbacks = array();
+    static $blacklist = array();
+    static $importListeners = array();
+    static $cacheLocation;
+}

--- a/lib/antecedent/patchwork/src/Preprocessor/Callbacks/Generic.php
+++ b/lib/antecedent/patchwork/src/Preprocessor/Callbacks/Generic.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Preprocessor\Callbacks\Generic;
+
+use Patchwork\Preprocessor\Source;
+use Patchwork\Utils;
+
+const LEFT_PARENTHESIS = "(";
+const RIGHT_PARENTHESIS = ")";
+const LEFT_CURLY_BRACKET = "{";
+const SEMICOLON = ";";
+
+function markPreprocessedFiles(&$target)
+{
+    return function($file) use (&$target) {
+        $target[$file] = true;
+    };
+}
+
+function prependCodeToFunctions($code)
+{
+    return function(Source $s) use ($code) {
+        foreach ($s->findAll(T_FUNCTION) as $function) {
+            $bracket = $s->findNext(LEFT_CURLY_BRACKET, $function);
+            if (Utils\generatorsSupported()) {
+                # Skip generators
+                $yield = $s->findNext(T_YIELD, $bracket);
+                if ($yield < $s->findMatchingBracket($bracket)) {
+                    continue;
+                }
+            }
+            $semicolon = $s->findNext(SEMICOLON, $function);
+            if ($bracket < $semicolon) {
+                $s->splice($code, $bracket + 1);
+            }
+        }
+    };
+}
+
+function wrapUnaryConstructArguments($construct, $wrapper)
+{
+    return function(Source $s) use ($construct, $wrapper) {
+        foreach ($s->findAll($construct) as $match) {
+            $pos = $s->findNext(LEFT_PARENTHESIS, $match);
+            $s->splice($wrapper . LEFT_PARENTHESIS, $pos + 1);
+            $s->splice(RIGHT_PARENTHESIS, $s->findMatchingBracket($pos));
+        }
+    };
+}
+
+function injectFalseExpressionAtBeginnings($expression)
+{
+    return function(Source $s) use ($expression) {
+        $openingTags = $s->findAll(T_OPEN_TAG);
+        $openingTagsWithEcho = $s->findAll(T_OPEN_TAG_WITH_ECHO);
+        if (empty($openingTags) && empty($openingTagsWithEcho)) {
+            return;
+        }
+        if (!empty($openingTags) &&
+            (empty($openingTagsWithEcho) || reset($openingTags) < reset($openingTagsWithEcho))) {
+            $pos = reset($openingTags);
+            $namespaceKeyword = $s->findNext(T_NAMESPACE, $pos);
+            if ($namespaceKeyword !== INF) {
+                $semicolon = $s->findNext(SEMICOLON, $namespaceKeyword);
+                $leftBracket = $s->findNext(LEFT_CURLY_BRACKET, $namespaceKeyword);
+                $pos = min($semicolon, $leftBracket);
+            }
+            $s->splice(' ' . $expression . ";", $pos + 1);
+        } else {
+            $openingTag = reset($openingTagsWithEcho);
+            $closingTag = $s->findNext(T_CLOSE_TAG, $openingTag);
+            $semicolon = $s->findNext(SEMICOLON, $openingTag);
+            $s->splice(' (' . $expression . ') ?: (', $openingTag + 1);
+            $s->splice(') ', min($closingTag, $semicolon));
+        }
+    };
+}
+
+function injectCodeAfterClassDefinitions($code)
+{
+    return function(Source $s) use ($code) {
+        foreach ($s->findAll(T_CLASS) as $match) {
+            if ($s->findNext(T_DOUBLE_COLON, $match - 3) < $match) {
+                # ::class syntax, not a class definition
+                continue;
+            }
+            $leftBracket = $s->findNext(LEFT_CURLY_BRACKET, $match);
+            if ($leftBracket === INF) {
+                continue;
+            }
+            $rightBracket = $s->findMatchingBracket($leftBracket);
+            if ($rightBracket === INF) {
+                continue;
+            }
+            $s->splice($code, $rightBracket + 1);
+        }
+    };
+}
+
+function chain(array $callbacks)
+{
+    return function(Source $s) use ($callbacks) {
+        foreach ($callbacks as $callback) {
+            $callback($s);
+        }
+    };
+}

--- a/lib/antecedent/patchwork/src/Preprocessor/Callbacks/Interceptor.php
+++ b/lib/antecedent/patchwork/src/Preprocessor/Callbacks/Interceptor.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Preprocessor\Callbacks\Interceptor;
+
+use Patchwork\Preprocessor\Callbacks\Generic;
+use Patchwork\Interceptor;
+use Patchwork\Utils;
+
+const CALL_INTERCEPTION_CODE = '
+    $__pwClosureName = __NAMESPACE__ ? __NAMESPACE__ . "\\{closure}" : "{closure}";
+    $__pwClass = (__CLASS__ && __FUNCTION__ !== $__pwClosureName) ? __CLASS__ : null;
+    if (!empty(\Patchwork\Interceptor\State::$patches[$__pwClass][__FUNCTION__])) {
+        $__pwCalledClass = $__pwClass ? \get_called_class() : null;
+        $__pwFrame = \count(\debug_backtrace(false));
+        if (\Patchwork\Interceptor\intercept($__pwClass, $__pwCalledClass, __FUNCTION__, $__pwFrame, $__pwResult)) {
+            return $__pwResult;
+        }
+    }
+    unset($__pwClass, $__pwCalledClass, $__pwResult, $__pwClosureName, $__pwFrame);
+';
+
+const QUEUE_DEPLOYMENT_CODE = '\Patchwork\Interceptor\deployQueue()';
+
+function markPreprocessedFiles()
+{
+    return Generic\markPreprocessedFiles(Interceptor\State::$preprocessedFiles);
+}
+
+function injectCallInterceptionCode()
+{
+    return Generic\prependCodeToFunctions(Utils\condense(CALL_INTERCEPTION_CODE));
+}
+
+function injectQueueDeploymentCode()
+{
+    return Generic\chain(array(
+        Generic\injectFalseExpressionAtBeginnings(QUEUE_DEPLOYMENT_CODE),
+        Generic\injectCodeAfterClassDefinitions(QUEUE_DEPLOYMENT_CODE . ';'),
+    ));
+}

--- a/lib/antecedent/patchwork/src/Preprocessor/Callbacks/Preprocessor.php
+++ b/lib/antecedent/patchwork/src/Preprocessor/Callbacks/Preprocessor.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Preprocessor\Callbacks\Preprocessor;
+
+use Patchwork\Preprocessor\Callbacks\Generic;
+use Patchwork\Preprocessor\Source;
+
+const EVAL_ARGUMENT_WRAPPER = '\Patchwork\Preprocessor\preprocessForEval';
+
+function propagateThroughEval()
+{
+    return Generic\wrapUnaryConstructArguments(T_EVAL, EVAL_ARGUMENT_WRAPPER);
+}
+
+function flush()
+{
+    return function(Source $s) {
+        $s->flush();
+    };
+}

--- a/lib/antecedent/patchwork/src/Preprocessor/Source.php
+++ b/lib/antecedent/patchwork/src/Preprocessor/Source.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Preprocessor;
+
+use Patchwork\Utils;
+
+class Source
+{
+    const TYPE_OFFSET = 0;
+    const STRING_OFFSET = 1;
+
+    public $tokens;
+    public $tokensByType;
+    public $splices;
+    public $spliceLengths;
+    public $code;
+    public $file;
+    public $matchingBrackets;
+
+    public function __construct($tokens)
+    {
+        $this->initialize(is_array($tokens) ? $tokens : token_get_all($tokens));
+    }
+
+    public function initialize(array $tokens)
+    {
+        $this->tokens = $tokens;
+        $this->tokens[] = array(T_WHITESPACE, "");
+        $this->tokensByType = $this->indexTokensByType($this->tokens);
+        $this->matchingBrackets = $this->matchBrackets($this->tokens);
+        $this->splices = $this->spliceLengths = array();
+    }
+
+    public function indexTokensByType(array $tokens)
+    {
+        $tokensByType = array();
+        foreach ($tokens as $offset => $token) {
+            $tokensByType[$token[self::TYPE_OFFSET]][] = $offset;
+        }
+        return $tokensByType;
+    }
+
+    public function matchBrackets(array $tokens)
+    {
+        $matches = array();
+        $stack = array();
+        foreach ($tokens as $offset => $token) {
+            $type = $token[self::TYPE_OFFSET];
+            switch ($type) {
+                case '(':
+                case '[':
+                case '{':
+                case T_CURLY_OPEN:
+                case T_DOLLAR_OPEN_CURLY_BRACES:
+                    $stack[] = $offset;
+                    break;
+                case ')':
+                case ']':
+                case '}':
+                    $top = array_pop($stack);
+                    $matches[$top] = $offset;
+                    $matches[$offset] = $top;
+                    break;
+            }
+        }
+        return $matches;
+    }
+
+    public function findNext($type, $offset)
+    {
+        if (!isset($this->tokensByType[$type])) {
+            return INF;
+        }
+        $next = Utils\findFirstGreaterThan($this->tokensByType[$type], $offset);
+        return isset($this->tokensByType[$type][$next]) ? $this->tokensByType[$type][$next] : INF;
+    }
+
+    public function findAll($type)
+    {
+        $tokens = &$this->tokensByType[$type];
+        if (!isset($tokens)) {
+            $tokens = array();
+        }
+        return $tokens;
+    }
+
+    public function findMatchingBracket($offset)
+    {
+        return isset($this->matchingBrackets[$offset]) ? $this->matchingBrackets[$offset] : INF;
+    }
+
+    public function splice($splice, $offset, $length = 0)
+    {
+        $this->splices[$offset] = $splice;
+        $this->spliceLengths[$offset] = $length;
+        $this->code = null;
+    }
+
+    public function createCodeFromTokens()
+    {
+        $splices = $this->splices;
+        $code = "";
+        $count = count($this->tokens);
+        for ($offset = 0; $offset < $count; $offset++) {
+            if (isset($splices[$offset])) {
+                $code .= $splices[$offset];
+                unset($splices[$offset]);
+                $offset += $this->spliceLengths[$offset] - 1;
+            } else {
+                $t = $this->tokens[$offset];
+                $code .= isset($t[self::STRING_OFFSET]) ? $t[self::STRING_OFFSET] : $t;
+            }
+        }
+        $this->code = $code;
+    }
+
+    public function __toString()
+    {
+        if ($this->code === null) {
+            $this->createCodeFromTokens();
+        }
+        return (string) $this->code;
+    }
+
+    public function flush()
+    {
+        $this->initialize(token_get_all($this));
+    }
+}

--- a/lib/antecedent/patchwork/src/Preprocessor/Stream.php
+++ b/lib/antecedent/patchwork/src/Preprocessor/Stream.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Preprocessor;
+
+use Patchwork\Utils;
+
+class Stream
+{
+    const STREAM_OPEN_FOR_INCLUDE = 128;
+    const STAT_MTIME_NUMERIC_OFFSET = 9;
+    const STAT_MTIME_ASSOC_OFFSET = 'mtime';
+
+    protected static $protocols = array('file', 'phar');
+
+    public $context;
+    public $resource;
+
+    public static function wrap()
+    {
+        foreach (static::$protocols as $protocol) {
+            stream_wrapper_unregister($protocol);
+            stream_wrapper_register($protocol, get_called_class());
+        }
+    }
+
+    public static function unwrap()
+    {
+        foreach (static::$protocols as $protocol) {
+            stream_wrapper_restore($protocol);
+        }
+    }
+
+    public function stream_open($path, $mode, $options, &$openedPath)
+    {
+        $this->unwrap();
+        $including = (bool) ($options & self::STREAM_OPEN_FOR_INCLUDE);
+        if ($including && shouldPreprocess($path)) {
+            $this->resource = preprocessAndOpen($path);
+            $this->wrap();
+            return true;
+        }
+        if (isset($this->context)) {
+            $this->resource = fopen($path, $mode, $options, $this->context);
+        } else {
+            $this->resource = fopen($path, $mode, $options);
+        }
+        $this->wrap();
+        return $this->resource !== false;
+    }
+
+    public function stream_close()
+    {
+        return fclose($this->resource);
+    }
+
+    public function stream_eof()
+    {
+        return feof($this->resource);
+    }
+
+    public function stream_flush()
+    {
+        return fflush($this->resource);
+    }
+
+    public function stream_read($count)
+    {
+        return fread($this->resource, $count);
+    }
+
+    public function stream_seek($offset, $whence = SEEK_SET)
+    {
+        return fseek($this->resource, $offset, $whence) === 0;
+    }
+
+    public function stream_stat()
+    {
+        $result = fstat($this->resource);
+        if ($result) {
+            $result[self::STAT_MTIME_ASSOC_OFFSET]++;
+            $result[self::STAT_MTIME_NUMERIC_OFFSET]++;
+        }
+        return $result;
+    }
+
+    public function stream_tell()
+    {
+        return ftell($this->resource);
+    }
+
+    public function url_stat($path, $flags)
+    {
+        $this->unwrap();
+        if ($flags & STREAM_URL_STAT_QUIET) {
+            set_error_handler(function() {});
+        }
+        $result = stat($path);
+        if ($flags & STREAM_URL_STAT_QUIET) {
+            restore_error_handler();
+        }
+        $this->wrap();
+        if ($result) {
+            $result[self::STAT_MTIME_ASSOC_OFFSET]++;
+            $result[self::STAT_MTIME_NUMERIC_OFFSET]++;
+        }
+        return $result;
+    }
+
+    public function dir_closedir()
+    {
+        closedir($this->resource);
+        return true;
+    }
+
+    public function dir_opendir($path, $options)
+    {
+        $this->unwrap();
+        if (isset($this->context)) {
+            $this->resource = opendir($path, $this->context);
+        } else {
+            $this->resource = opendir($path);
+        }
+        $this->wrap();
+        return $this->resource !== false;
+    }
+
+    public function dir_readdir()
+    {
+        return readdir($this->resource);
+    }
+
+    public function dir_rewinddir()
+    {
+        rewinddir($this->resource);
+        return true;
+    }
+
+    public function mkdir($path, $mode, $options)
+    {
+        $this->unwrap();
+        if (isset($this->context)) {
+            $result = mkdir($path, $mode, $options, $this->context);
+        } else {
+            $result = mkdir($path, $mode, $options);
+        }
+        $this->wrap();
+        return $result;
+    }
+
+    public function rename($path_from, $path_to)
+    {
+        $this->unwrap();
+        if (isset($this->context)) {
+            $result = rename($path_from, $path_to, $this->context);
+        } else {
+            $result = rename($path_from, $path_to);
+        }
+        $this->wrap();
+        return $result;
+    }
+
+    public function rmdir($path, $options)
+    {
+        $this->unwrap();
+        if (isset($this->context)) {
+            $result = rmdir($path, $this->context);
+        } else {
+            $result = rmdir($path);
+        }
+        $this->wrap();
+        return $result;
+    }
+
+    public function stream_cast($cast_as)
+    {
+        return $this->resource;
+    }
+
+    public function stream_lock($operation)
+    {
+        return flock($this->resource, $operation);
+    }
+
+    public function stream_set_option($option, $arg1, $arg2)
+    {
+        switch ($option) {
+            case STREAM_OPTION_BLOCKING:
+                return stream_set_blocking($this->resource, $arg1);
+            case STREAM_OPTION_READ_TIMEOUT:
+                return stream_set_timeout($this->resource, $arg1, $arg2);
+            case STREAM_OPTION_WRITE_BUFFER:
+                return stream_set_write_buffer($this->resource, $arg1);
+            case STREAM_OPTION_READ_BUFFER:
+                return stream_set_read_buffer($this->resource, $arg1);
+        }
+    }
+
+    public function stream_write($data)
+    {
+        return fwrite($this->resource, $data);
+    }
+
+    public function unlink($path)
+    {
+        $this->unwrap();
+        if (isset($this->context)) {
+            $result = unlink($path, $this->context);
+        } else {
+            $result = unlink($path);
+        }
+        $this->wrap();
+        return $result;
+    }
+
+    public function stream_metadata($path, $option, $value)
+    {
+        $this->unwrap();
+        switch ($option) {
+            case STREAM_META_TOUCH:
+                if (empty($value)) {
+                    $result = touch($path);
+                } else {
+                    $result = touch($path, $value[0], $value[1]);
+                }
+                break;
+            case STREAM_META_OWNER_NAME:
+            case STREAM_META_OWNER:
+                $result = chown($path, $value);
+                break;
+            case STREAM_META_GROUP_NAME:
+            case STREAM_META_GROUP:
+                $result = chgrp($path, $value);
+                break;
+            case STREAM_META_ACCESS:
+                $result = chmod($path, $value);
+                break;
+        }
+        $this->wrap();
+        return $result;
+    }
+
+    public function stream_truncate($new_size)
+    {
+        return ftruncate($this->resource, $new_size);
+    }
+}

--- a/lib/antecedent/patchwork/src/Stack.php
+++ b/lib/antecedent/patchwork/src/Stack.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Stack;
+
+use Patchwork\Exceptions;
+
+function push($offset, $calledClass, array $argsOverride = null)
+{
+    State::$items[] = array($offset, $calledClass, $argsOverride);
+}
+
+function pop()
+{
+    array_pop(State::$items);
+}
+
+function pushFor($offset, $calledClass, $callback, array $argsOverride = null)
+{
+    push($offset, $calledClass, $argsOverride);
+    try {
+        $callback();
+    } catch (\Exception $e) {
+        $exception = $e;
+    }
+    pop();
+    if (isset($exception)) {
+        throw $exception;
+    }
+}
+
+function top($property = null)
+{
+    $all = all();
+    $frame = reset($all);
+    $argsOverride = topArgsOverride();
+    if ($argsOverride !== null) {
+        $frame["args"] = $argsOverride;
+    }
+    if ($property) {
+        return isset($frame[$property]) ? $frame[$property] : null;
+    }
+    return $frame;
+}
+
+function topOffset()
+{
+    if (empty(State::$items)) {
+        throw new Exceptions\StackEmpty;
+    }
+    list($offset, $calledClass) = end(State::$items);
+    return $offset;
+}
+
+function topCalledClass()
+{
+    if (empty(State::$items)) {
+        throw new Exceptions\StackEmpty;
+    }
+    list($offset, $calledClass) = end(State::$items);
+    return $calledClass;
+}
+
+function topArgsOverride()
+{
+    if (empty(State::$items)) {
+        throw new Exceptions\StackEmpty;
+    }
+    list($offset, $calledClass, $argsOverride) = end(State::$items);
+    return $argsOverride;
+}
+
+function all()
+{
+    $backtrace = debug_backtrace();
+    return array_slice($backtrace, count($backtrace) - topOffset());
+}
+
+function allCalledClasses()
+{
+    return array_map(function($item) {
+        list($offset, $calledClass) = $item;
+        return $calledClass;
+    }, State::$items);
+}
+
+class State
+{
+    static $items = array();
+}

--- a/lib/antecedent/patchwork/src/Utils.php
+++ b/lib/antecedent/patchwork/src/Utils.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ */
+namespace Patchwork\Utils;
+
+function clearOpcodeCaches()
+{
+    if (ini_get('wincache.ocenabled')) {
+        wincache_refresh_if_changed();
+    }
+    if (ini_get('apc.enabled')) {
+        apc_clear_cache();
+    }
+}
+
+function traitsSupported()
+{
+    return version_compare(PHP_VERSION, "5.4", ">=");
+}
+
+function generatorsSupported()
+{
+    return version_compare(PHP_VERSION, "5.5", ">=");
+}
+
+function runningOnHHVM()
+{
+    return defined("HHVM_VERSION");
+}
+
+function condense($string)
+{
+    return preg_replace("/\s*/", "", $string);
+}
+
+function findFirstGreaterThan(array $array, $value)
+{
+    $low = 0;
+    $high = count($array) - 1;
+    if ($array[$high] <= $value) {
+        return $high + 1;
+    }
+    while ($low < $high) {
+        $mid = (int) (($low + $high) / 2);
+        if ($array[$mid] <= $value) {
+            $low = $mid + 1;
+        } else {
+            $high = $mid;
+        }
+    }
+    return $low;
+}
+
+function interpretCallback($callback)
+{
+    if (is_object($callback)) {
+        return interpretCallback(array($callback, "__invoke"));
+    }
+    if (is_array($callback)) {
+        list($class, $method) = $callback;
+        $instance = null;
+        if (is_object($class)) {
+            $instance = $class;
+            $class = get_class($class);
+        }
+        $class = ltrim($class, "\\");
+        return array($class, $method, $instance);
+    }
+    $callback = ltrim($callback, "\\");
+    if (strpos($callback, "::")) {
+        list($class, $method) = explode("::", $callback);
+        return array($class, $method, null);
+    }
+    return array(null, $callback, null);
+}
+
+function callbackTargetDefined($callback, $shouldAutoload = false)
+{
+    list($class, $method, $instance) = interpretCallback($callback);
+    if ($instance !== null) {
+        return true;
+    }
+    if (isset($class)) {
+        return classOrTraitExists($class, $shouldAutoload) &&
+               method_exists($class, $method);
+    }
+    return function_exists($method);
+}
+
+function classOrTraitExists($classOrTrait, $shouldAutoload = true)
+{
+    if (traitsSupported()) {
+        if (trait_exists($classOrTrait, $shouldAutoload)) {
+            return true;
+        }
+    }
+    return class_exists($classOrTrait, $shouldAutoload);
+}
+
+function append(&$array, $value)
+{
+    $array[] = $value;
+    end($array);
+    return key($array);
+}
+
+function normalizePath($path)
+{
+    return rtrim(strtr($path, "\\", "/"), "/");
+}
+
+function reflectCallback($callback)
+{
+    if ($callback instanceof \Closure) {
+        return new \ReflectionFunction($callback);
+    }
+    list($class, $method) = interpretCallback($callback);
+    if (isset($class)) {
+        return new \ReflectionMethod($class, $method);
+    }
+    return new \ReflectionFunction($method);
+}
+
+function callbackToString($callback)
+{
+    list($class, $method) = interpretCallback($callback);
+    if (isset($class)) {
+        return $class . "::" . $method;
+    }
+    return $method;
+}

--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once( __DIR__ . '/lib/antecedent/patchwork/Patchwork.php' );
+
 global $_plugin_file;
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );


### PR DESCRIPTION
Heres a pull request that adds antecedent, which will allow you to mock wordpress functions in unit tests. The easiest way to do this is to use a tool like WP_Mock (https://github.com/10up/wp_mock).

This basically means that you can make, for example get_posts return a mocked set of 3 posts.

This would be useful if you have logic that depends on whats inside the post (for example, different logic for various post_type's). You could give the mocked posts different post_types for each test, to ensure you get 100% code coverage.
