### PR TITLE
Badge for Pro services

### DIFF
--- a/class-wordpress-readme-parser.php
+++ b/class-wordpress-readme-parser.php
@@ -210,7 +210,7 @@ class WordPress_Readme_Parser {
 					$badge_md .= sprintf( '[![Build Status](%1$s.svg?branch=master)](%1$s) ', $url );
 				}
 				if ( 'coveralls_url' === $badge ) {
-					$badge_md .= sprintf( '[![Coverage Status](%s?branch=master)](%s) ', $params['coveralls_badge_src'], $url );
+					$badge_md .= sprintf( '[![Coverage Status](%s)](%s) ', $params['coveralls_badge_src'], $url );
 				}
 				if ( 'grunt_url' === $badge ) {
 					$badge_md .= sprintf( '[![Built with Grunt](https://cdn.%1$s/builtwith.png)](http://%1$s) ', $url );

--- a/class-wordpress-readme-parser.php
+++ b/class-wordpress-readme-parser.php
@@ -184,25 +184,61 @@ class WordPress_Readme_Parser {
 			$markdown .= sprintf( "**%s:** %s  \n", $name, $value );
 		}
 
-		if ( isset( $params['travis_ci_url'] ) || isset( $params['coveralls_url'] ) ) {
+		// All of the supported badges.
+		$badges = array(
+			'travis_ci_pro_url',
+			'travis_ci_url',
+			'coveralls_url',
+			'grunt_url',
+			'david_url',
+			'david_dev_url',
+			'gemnasium_url',
+			'gemnasium_dev_url',
+			'gitter_url',
+		);
+
+		$badge_md = '';
+
+		for ( $i = 0; $i < count( $badges ); $i++ ) {
+			if ( isset( $params[ $badges[ $i ] ] ) ) {
+				$badge = $badges[ $i ];
+				$url = $params[ $badge ];
+				if ( 'travis_ci_pro_url' === $badge ) {
+					$badge_md .= sprintf( '[![Build Status](%1$s)](%2$s) ', $params['travis_ci_pro_badge_src'], $url );
+				}
+				if ( 'travis_ci_url' === $badge ) {
+					$badge_md .= sprintf( '[![Build Status](%1$s.svg?branch=master)](%1$s) ', $url );
+				}
+				if ( 'coveralls_url' === $badge ) {
+					$badge_md .= sprintf( '[![Coverage Status](%s?branch=master)](%s) ', $params['coveralls_badge_src'], $url );
+				}
+				if ( 'grunt_url' === $badge ) {
+					$badge_md .= sprintf( '[![Built with Grunt](https://cdn.%1$s/builtwith.png)](http://%1$s) ', $url );
+				}
+				if ( 'david_url' === $badge ) {
+					$badge_md .= sprintf( '[![Dependency Status](%1$s.svg)](%1$s) ', $url );
+				}
+				if ( 'david_dev_url' === $badge ) {
+					$badge_md .= sprintf( '[![devDependency Status](%1$s/dev-status.svg)](%1$s#info=devDependencies) ', $url );
+				}
+				if ( 'gemnasium_url' === $badge ) {
+					$badge_md .= sprintf( '[![Dependency Status](%1$s)](%2$s) ', $params['gemnasium_badge_src'], $url );
+				}
+				if ( 'gemnasium_dev_url' === $badge ) {
+					$badge_md .= sprintf( '[![devDependency Status](%1$s)](%2$s#development-dependencies) ', $params['gemnasium_dev_badge_src'], $url );
+				}
+				if ( 'gitter_url' === $badge ) {
+					$badge_md .= sprintf( '[![Join the chat at %1$s](https://badges.gitter.im/Join Chat.svg)](%1$s) ', $url );
+				}
+			}
+		}
+
+		if ( ! empty( $badge_md ) ) {
 			$markdown .= "\n";
-			if ( isset( $params['travis_ci_url'] ) ) {
-				$markdown .= sprintf( '[![Build Status](%1$s.svg?branch=master)](%1$s) ', $params['travis_ci_url'] );
-			}
-			if ( isset( $params['coveralls_url'] ) ) {
-				$markdown .= sprintf( '[![Coverage Status](%s?branch=master)](%s) ', $params['coveralls_badge_src'], $params['coveralls_url'] );
-			}
-			if ( isset( $params['gitter_url'] ) ) {
-				$markdown .= sprintf( '[![Join the chat at %1$s](https://badges.gitter.im/Join%20Chat.svg)](%1$s) ', $params['gitter_url'] );
-			}
-			if ( isset( $params['david_url'] ) ) {
-				$markdown .= sprintf( '[![Dependency Status](%1$s.svg)](%1$s) ', $params['david_url'] );
-			}
-			if ( isset( $params['david_dev_url'] ) ) {
-				$markdown .= sprintf( '[![devDependency Status](%1$s/dev-status.svg)](%1$s#info=devDependencies) ', $params['david_dev_url'] );
-			}
+			$markdown .= $badge_md;
 			$markdown .= "\n";
 		}
+
 		$markdown .= "\n";
 
 		foreach ( $this->sections as $section ) {

--- a/class-wordpress-readme-parser.php
+++ b/class-wordpress-readme-parser.php
@@ -190,7 +190,7 @@ class WordPress_Readme_Parser {
 				$markdown .= sprintf( '[![Build Status](%1$s.svg?branch=master)](%1$s) ', $params['travis_ci_url'] );
 			}
 			if ( isset( $params['coveralls_url'] ) ) {
-				$markdown .= sprintf( '[![Build Status](%s?branch=master)](%s) ', $params['coveralls_badge_src'], $params['coveralls_url'] );
+				$markdown .= sprintf( '[![Coverage Status](%s?branch=master)](%s) ', $params['coveralls_badge_src'], $params['coveralls_url'] );
 			}
 			if ( isset( $params['gitter_url'] ) ) {
 				$markdown .= sprintf( '[![Join the chat at %1$s](https://badges.gitter.im/Join%20Chat.svg)](%1$s) ', $params['gitter_url'] );

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -60,13 +60,25 @@ try {
 		}
 	}
 	if ( $github_account_repo ) {
-		if ( file_exists( $readme_root . '/.travis.yml' ) ) {
-			if ( file_exists( $readme_root . '/.travis-pro' ) ) {
-				$token = file_get_contents( $readme_root . '/.travis-pro' );
-				if ( false != $token ) { 
-					$md_args['travis_ci_pro_url'] = "https://magnum.travis-ci.com/$github_account_repo";
-					$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$token&branch=master";
+		$env_file = $readme_root . '/.ci-env.sh';
+		if ( file_exists( $env_file ) ) {
+			$lines = file( $env_file, FILE_IGNORE_NEW_LINES );
+			foreach( $lines as $line ) {
+				if ( preg_match( '/^COVERALLS_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
+					$coveralls = $matches[1];
+				} else if ( preg_match( '/^GEMNASIUM_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
+					$gemnasium = $matches[1];
+				} else if ( preg_match( '/^GEMNASIUM_DEV_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
+					$gemnasium_dev = $matches[1];
+				} else if ( preg_match( '/^TRAVIS_CI_PRO_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
+					$travis = $matches[1];
 				}
+			}
+		}
+		if ( file_exists( $readme_root . '/.travis.yml' ) ) {
+			if ( isset( $travis ) ) {
+				$md_args['travis_ci_pro_url'] = "https://magnum.travis-ci.com/$github_account_repo";
+				$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$travis&branch=master";
 			}
 			if ( ! isset( $md_args['travis_ci_pro_url'] ) ) {
 				$md_args['travis_ci_url'] = "https://travis-ci.org/$github_account_repo";
@@ -75,11 +87,8 @@ try {
 		if ( file_exists( $readme_root . '/.coveralls.yml' ) ) {
 			$md_args['coveralls_url'] = "https://coveralls.io/github/$github_account_repo";
 			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.svg?branch=master";
-			if ( file_exists( $readme_root . '/.coveralls-pro' ) ) {
-				$token = file_get_contents( $readme_root . '/.coveralls-pro' );
-				if ( false != $token ) {
-					$md_args['coveralls_badge_src'] .= "&service=github&t=$token";
-				}
+			if ( isset( $coveralls ) ) {
+				$md_args['coveralls_badge_src'] .= "&service=github&t=$coveralls";
 			}
 		}
 		if ( file_exists( $readme_root . '/Gruntfile.js' ) ) {
@@ -91,19 +100,13 @@ try {
 		if ( file_exists( $readme_root . '/.david-dev' ) ) {
 			$md_args['david_dev_url'] = "https://david-dm.org/$github_account_repo";
 		}
-		if ( file_exists( $readme_root . '/.gemnasium' ) ) {
-			$token = file_get_contents( $readme_root . '/.gemnasium' );
-			if ( false != $token ) { 
-				$md_args['gemnasium_url'] = "https://gemnasium.com/$github_account_repo";
-				$md_args['gemnasium_badge_src'] = "https://gemnasium.com/$token.svg";
-			}
+		if ( isset( $gemnasium ) ) {
+			$md_args['gemnasium_url'] = "https://gemnasium.com/$github_account_repo";
+			$md_args['gemnasium_badge_src'] = "https://gemnasium.com/$gemnasium.svg";
 		}
-		if ( file_exists( $readme_root . '/.gemnasium-dev' ) ) {
-			$token = file_get_contents( $readme_root . '/.gemnasium-dev' );
-			if ( false != $token ) { 
-				$md_args['gemnasium_dev_url'] = "https://gemnasium.com/$github_account_repo";
-				$md_args['gemnasium_dev_badge_src'] = "https://gemnasium.com/$token.svg";
-			}
+		if ( isset( $gemnasium_dev ) ) {
+			$md_args['gemnasium_dev_url'] = "https://gemnasium.com/$github_account_repo";
+			$md_args['gemnasium_dev_badge_src'] = "https://gemnasium.com/$gemnasium_dev.svg";
 		}
 		if ( file_exists( $readme_root . '/.gitter' ) ) {
 			$md_args['gitter_url'] = "https://gitter.im/$github_account_repo";

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -61,20 +61,46 @@ try {
 	}
 	if ( $github_account_repo ) {
 		if ( file_exists( $readme_root . '/.travis.yml' ) ) {
-			$md_args['travis_ci_url'] = "https://travis-ci.org/$github_account_repo";
+			if ( file_exists( $readme_root . '/.travis-pro' ) ) {
+				$token = file_get_contents( $readme_root . '/.travis-pro' );
+				if ( false != $token ) { 
+					$md_args['travis_ci_pro_url'] = "https://magnum.travis-ci.com/$github_account_repo";
+					$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$token&branch=master";
+				}
+			}
+			if ( ! isset( $md_args['travis_ci_pro_url'] ) ) {
+				$md_args['travis_ci_url'] = "https://travis-ci.org/$github_account_repo";
+			}
 		}
 		if ( file_exists( $readme_root . '/.coveralls.yml' ) ) {
-			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.svg";
 			$md_args['coveralls_url'] = "https://coveralls.io/github/$github_account_repo";
+			$md_args['coveralls_badge_src'] = $md_args['coveralls_url'] . "/badge.svg";
 		}
-		if ( file_exists( $readme_root . '/.gitter' ) ) {
-			$md_args['gitter_url'] = "https://gitter.im/$github_account_repo";
+		if ( file_exists( $readme_root . '/Gruntfile.js' ) ) {
+			$md_args['grunt_url'] = "gruntjs.com";
 		}
 		if ( file_exists( $readme_root . '/.david' ) ) {
 			$md_args['david_url'] = "https://david-dm.org/$github_account_repo";
 		}
 		if ( file_exists( $readme_root . '/.david-dev' ) ) {
 			$md_args['david_dev_url'] = "https://david-dm.org/$github_account_repo";
+		}
+		if ( file_exists( $readme_root . '/.gemnasium' ) ) {
+			$token = file_get_contents( $readme_root . '/.gemnasium' );
+			if ( false != $token ) { 
+				$md_args['gemnasium_url'] = "https://gemnasium.com/$github_account_repo";
+				$md_args['gemnasium_badge_src'] = "https://gemnasium.com/$token.svg";
+			}
+		}
+		if ( file_exists( $readme_root . '/.gemnasium-dev' ) ) {
+			$token = file_get_contents( $readme_root . '/.gemnasium-dev' );
+			if ( false != $token ) { 
+				$md_args['gemnasium_dev_url'] = "https://gemnasium.com/$github_account_repo";
+				$md_args['gemnasium_dev_badge_src'] = "https://gemnasium.com/$token.svg";
+			}
+		}
+		if ( file_exists( $readme_root . '/.gitter' ) ) {
+			$md_args['gitter_url'] = "https://gitter.im/$github_account_repo";
 		}
 	}
 	$markdown = $readme->to_markdown( $md_args );

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -74,7 +74,7 @@ try {
 		}
 		if ( file_exists( $readme_root . '/.coveralls.yml' ) ) {
 			$md_args['coveralls_url'] = "https://coveralls.io/github/$github_account_repo";
-			$md_args['coveralls_badge_src'] = $md_args['coveralls_url'] . "/badge.svg";
+			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.svg";
 		}
 		if ( file_exists( $readme_root . '/Gruntfile.js' ) ) {
 			$md_args['grunt_url'] = "gruntjs.com";

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -74,7 +74,13 @@ try {
 		}
 		if ( file_exists( $readme_root . '/.coveralls.yml' ) ) {
 			$md_args['coveralls_url'] = "https://coveralls.io/github/$github_account_repo";
-			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.svg";
+			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.svg?branch=master";
+			if ( file_exists( $readme_root . '/.coveralls-pro' ) ) {
+				$token = file_get_contents( $readme_root . '/.coveralls-pro' );
+				if ( false != $token ) {
+					$md_args['coveralls_badge_src'] .= "&service=github&t=$token";
+				}
+			}
 		}
 		if ( file_exists( $readme_root . '/Gruntfile.js' ) ) {
 			$md_args['grunt_url'] = "gruntjs.com";

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -60,25 +60,26 @@ try {
 		}
 	}
 	if ( $github_account_repo ) {
-		$env_file = $readme_root . '/.ci-env.sh';
-		if ( file_exists( $env_file ) ) {
-			$lines = file( $env_file, FILE_IGNORE_NEW_LINES );
-			foreach( $lines as $line ) {
-				if ( preg_match( '/^COVERALLS_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
-					$coveralls = $matches[1];
-				} else if ( preg_match( '/^GEMNASIUM_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
-					$gemnasium = $matches[1];
-				} else if ( preg_match( '/^GEMNASIUM_DEV_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
-					$gemnasium_dev = $matches[1];
-				} else if ( preg_match( '/^TRAVIS_CI_PRO_BADGE\s*=\s*(.+?)$/', $line, $matches ) ) {
-					$travis = $matches[1];
-				}
+		$env_ini = $readme_root . '/.ci-env.sh';
+		if ( file_exists( $env_ini ) ) {
+			$env_vars = parse_ini_file( $env_ini );
+			if ( isset( $env_vars['COVERALLS_BADGE'] ) ) {
+				$coveralls_badge = $env_vars['COVERALLS_BADGE'];
+			}
+			if ( isset( $env_vars['GEMNASIUM_BADGE'] ) ) {
+				$gemnasium_badge = $env_vars['GEMNASIUM_BADGE'];
+			}
+			if ( isset( $env_vars['GEMNASIUM_DEV_BADGE'] ) ) {
+				$gemnasium_dev_badge = $env_vars['GEMNASIUM_DEV_BADGE'];
+			}
+			if ( isset( $env_vars['TRAVIS_CI_PRO_BADGE'] ) ) {
+				$travis_ci_pro_badge = $env_vars['TRAVIS_CI_PRO_BADGE'];
 			}
 		}
 		if ( file_exists( $readme_root . '/.travis.yml' ) ) {
-			if ( isset( $travis ) ) {
+			if ( isset( $travis_ci_pro_badge ) ) {
 				$md_args['travis_ci_pro_url'] = "https://magnum.travis-ci.com/$github_account_repo";
-				$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$travis&branch=master";
+				$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$travis_ci_pro_badge&branch=master";
 			}
 			if ( ! isset( $md_args['travis_ci_pro_url'] ) ) {
 				$md_args['travis_ci_url'] = "https://travis-ci.org/$github_account_repo";
@@ -87,8 +88,8 @@ try {
 		if ( file_exists( $readme_root . '/.coveralls.yml' ) ) {
 			$md_args['coveralls_url'] = "https://coveralls.io/github/$github_account_repo";
 			$md_args['coveralls_badge_src'] = "https://coveralls.io/repos/$github_account_repo/badge.svg?branch=master";
-			if ( isset( $coveralls ) ) {
-				$md_args['coveralls_badge_src'] .= "&service=github&t=$coveralls";
+			if ( isset( $coveralls_badge ) ) {
+				$md_args['coveralls_badge_src'] .= "&service=github&t=$coveralls_badge";
 			}
 		}
 		if ( file_exists( $readme_root . '/Gruntfile.js' ) ) {
@@ -100,13 +101,13 @@ try {
 		if ( file_exists( $readme_root . '/.david-dev' ) ) {
 			$md_args['david_dev_url'] = "https://david-dm.org/$github_account_repo";
 		}
-		if ( isset( $gemnasium ) ) {
+		if ( isset( $gemnasium_badge ) ) {
 			$md_args['gemnasium_url'] = "https://gemnasium.com/$github_account_repo";
-			$md_args['gemnasium_badge_src'] = "https://gemnasium.com/$gemnasium.svg";
+			$md_args['gemnasium_badge_src'] = "https://gemnasium.com/$gemnasium_badge.svg";
 		}
-		if ( isset( $gemnasium_dev ) ) {
+		if ( isset( $gemnasium_dev_badge ) ) {
 			$md_args['gemnasium_dev_url'] = "https://gemnasium.com/$github_account_repo";
-			$md_args['gemnasium_dev_badge_src'] = "https://gemnasium.com/$gemnasium_dev.svg";
+			$md_args['gemnasium_dev_badge_src'] = "https://gemnasium.com/$gemnasium_dev_badge.svg";
 		}
 		if ( file_exists( $readme_root . '/.gitter' ) ) {
 			$md_args['gitter_url'] = "https://gitter.im/$github_account_repo";


### PR DESCRIPTION
This PR adds support to generate badges for Travis CI Pro, Coveralls Pro, & Gemnasium. I also added a Grunt.js badge and fixed the Gitter.im badge.

[![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com)
[![Join the chat at https://gitter.im/xwp/wp-dev-lib](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/xwp/wp-dev-lib)

To generate a Travis CI Pro badge you need to add a `.travis-pro` file with the user token required to generate the `svg` pasted in it.

To generate a Coveralls Pro badge you need to add a `.coveralls-pro` file with the user token required to generate the `svg` pasted in it.