### PR TITLE
Unset Git working tree

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -337,6 +337,7 @@ function install_tools {
 
 			if ! phpcs -i | grep -q 'WordPress'; then
 				if [ ! -e "$WPCS_DIR" ]; then
+				    unset GIT_WORK_TREE
 					git clone -b "$WPCS_GIT_TREE" "https://github.com/$WPCS_GITHUB_SRC.git" $WPCS_DIR
 				fi
 				phpcs --config-set installed_paths $WPCS_DIR

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -337,8 +337,8 @@ function install_tools {
 
 			if ! phpcs -i | grep -q 'WordPress'; then
 				if [ ! -e "$WPCS_DIR" ]; then
-				    GIT_WORK_TREE_RESTORE="$GIT_WORK_TREE"
-				    unset GIT_WORK_TREE
+					GIT_WORK_TREE_RESTORE="$GIT_WORK_TREE"
+					unset GIT_WORK_TREE
 					git clone -b "$WPCS_GIT_TREE" "https://github.com/$WPCS_GITHUB_SRC.git" $WPCS_DIR
 					GIT_WORK_TREE="$GIT_WORK_TREE_RESTORE"
 				fi

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -337,8 +337,10 @@ function install_tools {
 
 			if ! phpcs -i | grep -q 'WordPress'; then
 				if [ ! -e "$WPCS_DIR" ]; then
+				    GIT_WORK_TREE_RESTORE="$GIT_WORK_TREE"
 				    unset GIT_WORK_TREE
 					git clone -b "$WPCS_GIT_TREE" "https://github.com/$WPCS_GITHUB_SRC.git" $WPCS_DIR
+					GIT_WORK_TREE="$GIT_WORK_TREE_RESTORE"
 				fi
 				phpcs --config-set installed_paths $WPCS_DIR
 			fi


### PR DESCRIPTION
If you don't unset the GIT_WORK_TREE var, the WPCS fails to clone because it thinks the working tree already exists

@westonruter would like to have a discussion with you on this. It's rather complex :)