### PR TITLE
Parse bash vars manually instead of using parse_ini_file()

### DIFF
--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -62,14 +62,14 @@ try {
 		}
 	}
 	if ( $github_account_repo ) {
-		$env_ini = $readme_root . '/.dev-lib';
-		if ( ! file_exists( $env_ini ) ) {
-			$env_ini = $readme_root . '/.ci-env.sh';
+		$env_file = $readme_root . '/.dev-lib';
+		if ( ! file_exists( $env_file ) ) {
+			$env_file = $readme_root . '/.ci-env.sh';
 		}
-		if ( file_exists( $env_ini ) ) {
+		if ( file_exists( $env_file ) ) {
 
 			$env_vars = array();
-			if ( preg_match_all( '/^\s*(?!#)(?P<name>.+)=([\'"]?)(?P<value>.+)\2/m', file_get_contents( $env_ini ), $matches, PREG_SET_ORDER ) ) {
+			if ( preg_match_all( '/^\s*(?!#)(?P<name>.+)=([\'"]?)(?P<value>.+)\2/m', file_get_contents( $env_file ), $matches, PREG_SET_ORDER ) ) {
 				foreach ( $matches as $match ) {
 					$env_vars[ $match['name'] ] = $match['value'];
 				}

--- a/generate-markdown-readme
+++ b/generate-markdown-readme
@@ -67,7 +67,14 @@ try {
 			$env_ini = $readme_root . '/.ci-env.sh';
 		}
 		if ( file_exists( $env_ini ) ) {
-			$env_vars = parse_ini_file( $env_ini );
+
+			$env_vars = array();
+			if ( preg_match_all( '/^\s*(?!#)(?P<name>.+)=([\'"]?)(?P<value>.+)\2/m', file_get_contents( $env_ini ), $matches, PREG_SET_ORDER ) ) {
+				foreach ( $matches as $match ) {
+					$env_vars[ $match['name'] ] = $match['value'];
+				}
+			}
+
 			if ( isset( $env_vars['COVERALLS_BADGE'] ) ) {
 				$coveralls_badge = $env_vars['COVERALLS_BADGE'];
 			}


### PR DESCRIPTION
This implements rudimentary parsing of Bash vars. It won't handle any interpolation or escape sequences or anything like that.

Fixes #160