### PR TITLE
Add WordPress-Docs to default phpcs; add valid-jsdoc to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -145,6 +145,7 @@
 		"strict": [2, "function"],
 		"use-isnan": [2],
 		"valid-typeof": [2],
+		"valid-jsdoc": [2],
 		"vars-on-top": [0],
 		"wrap-iife": [2, "inside"],
 		"wrap-regex": [0],

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -3,6 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
 
 	<exclude-pattern>*/dev-lib/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>


### PR DESCRIPTION
Fixes #10.