### PR TITLE
Fix activation of plugins via WP_TEST_ACTIVATED_PLUGINS config

### DIFF
--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -55,7 +55,7 @@ function xwp_filter_active_plugins_for_phpunit( $active_plugins ) {
 	}
 	if ( ! empty( $forced_active_plugins ) ) {
 		foreach ( $forced_active_plugins as $forced_active_plugin ) {
-			$active_plugins[ "$forced_active_plugin" ] = time();
+			$active_plugins[] = $forced_active_plugin;
 		}
 	}
 	return $active_plugins;


### PR DESCRIPTION
The array format used was incorrect.