### PR TITLE
Ignore `node_modules` symlinks when installing `npm`.

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -765,8 +765,8 @@ function run_qunit {
 
 		cd "$( dirname "$gruntfile" )"
 
-		# Make sure Node packages are installed in this location.
-		if [ -e package.json ] && [ ! -e node_modules ]; then
+		# Make sure Node packages are installed in this location. Ignore symlink.
+		if [ -e package.json ] && [ ! -e node_modules -o -h node_modules ]; then
 			npm install
 		fi
 


### PR DESCRIPTION
Having symbolic link to `node_modules` in the project root (as e.g. in case of a client's plugins using global `node_modules` via symlink) generates Travis error:

```
Fatal error: Unable to find local grunt.
```

After removing `node_modules` symlinks in plugins, builds are okay.

However, having symlink in plugin's directory facilitates development, so it's not a best idea to remove them completely. In this case, I've modified `check-diff.sh` script to go ahead and ignore symlink. This way `npm` should be installed in each Travis build.

---

I'm open to any developer having a look and commenting/merging this into `master`.

@westonruter - I'm assigning this to you primarily, as you already saw my struggles with this issue.