### PR TITLE
Define Paths

### DIFF
--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -1,4 +1,10 @@
 <?php
+// Determine if we should update the content and plugin paths.
+if ( file_exists( dirname( __DIR__ ) . '/wp-load.php' ) ) {
+	define( 'WP_CONTENT_DIR', dirname( __DIR__ ) . '/wp-content/' );
+	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . 'plugins/' );
+}
+
 if ( file_exists( __DIR__ . '/../phpunit-plugin-bootstrap.project.php' ) ) {
     require_once( __DIR__ . '/../phpunit-plugin-bootstrap.project.php' );
 }


### PR DESCRIPTION
* Define paths to the current WP install instead of using the wordpress-develop paths as per the tests bootstrap

Hey @westonruter 

I think there will be a bit of back and forth on this one. I've added the initial attempt to fix out issues. In Slack you mentioned adding a condition based on whether the plugin is in the plugins folder. The problem with our repo is that we use the dev-lib in the project root. So the plugins do this:

`<phpunit
	bootstrap="../../../dev-lib/phpunit-plugin-bootstrap.php"
	backupGlobals="false"
	colors="true"
	convertErrorsToExceptions="true"
	convertNoticesToExceptions="true"
	convertWarningsToExceptions="true"
	>`

The fix in this branch solves the problem, but we may want to adapt it for more global usage? Thoughts?