### PR TITLE
Define root PHPUNIT_CONFIG if config exists

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -309,6 +309,13 @@ function set_environment_variables {
 	if [ ! -z "$PHPCS_RULESET_FILE" ]; then PHPCS_RULESET_FILE=$(realpath "$PHPCS_RULESET_FILE"); fi
 	if [ ! -z "$CODECEPTION_CONFIG" ]; then CODECEPTION_CONFIG=$(realpath "$CODECEPTION_CONFIG"); fi
 	if [ ! -z "$VAGRANTFILE" ]; then VAGRANTFILE=$(realpath "$VAGRANTFILE"); fi
+	if [ -z "$PHPUNIT_CONFIG" ] && ( [ -e phpunit.xml ] || [ -e phpunit.xml.dist ] ); then
+		if [ -e phpunit.xml ]; then
+			PHPUNIT_CONFIG=phpunit.xml
+		else
+			PHPUNIT_CONFIG=phpunit.xml.dist
+		fi
+	fi
 	# Note: PHPUNIT_CONFIG must be a relative path for the sake of running in Vagrant
 
 	return 0


### PR DESCRIPTION
Ensures that the root PHP unit will be run here:

``` bash
        echo "## phpunit"
        if [ -n "$( type -t phpunit )" ] && [ -n "$WP_TESTS_DIR" ]; then
            if [ -n "$PHPUNIT_CONFIG" ]; then
                phpunit $( if [ -n "$PHPUNIT_CONFIG" ]; then echo -c "$PHPUNIT_CONFIG"; fi )
```
