### PR TITLE
Fix the issue where symlinks acts funny in Windows + Git Bash

### DIFF
--- a/install-pre-commit-hook.sh
+++ b/install-pre-commit-hook.sh
@@ -42,5 +42,8 @@ fi
 echo "## Placing pre-commit file in $(pwd) from $RELPATH"
 ln -s "$RELPATH" .
 
+# A workaround for Windows envs where symlinks are not working properly, hardcoding the path to dev-lib
+echo "$BINDIR" > .dev-lib-path
+
 # Return back to the calling directory
 cd "$OLDPWD" &> /dev/null

--- a/pre-commit
+++ b/pre-commit
@@ -10,6 +10,8 @@ if [ -L "$0" ]; then
 	else
 		DEV_LIB_PATH=$( dirname $( readlink "$0" ) )
 	fi
+elif [ -e "$(dirname "$0")/.dev-lib-path" ]; then
+    DEV_LIB_PATH="$(realpath $(cat "$(dirname "$0")/.dev-lib-path"))"
 else
 	DEV_LIB_PATH=dev-lib
 fi


### PR DESCRIPTION
On Windows + Git Bash, symlinks do not work properly and the source of the symlink cannot be traced back, which breaks pre-commit script functionality, this PR tries to hardcode the path to dev-lib as a fall-back, only used if the symlink cannot be traced, and the path file exists.
