### PR TITLE
Install dev-lib to tempo directory if no version was found in default locations

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -16,7 +16,18 @@ fi
 
 if [ ! -e "$DEV_LIB_PATH/check-diff.sh" ]; then
 	echo "Unable to determine DEV_LIB_PATH"
-	exit 1
+
+    exec < /dev/tty # to be able to use read
+    read -p "Would you like to clone wp-dev-lib to a temporary dir? [y/N] " -r -n 1
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    else
+        echo
+	    DEV_LIB_PATH=/tmp/.wp-dev-lib
+	    if [ ! -e "$DEV_LIB_PATH" ]; then
+	        git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH
+        fi
+    fi
 fi
 
 source "$DEV_LIB_PATH/check-diff.sh"


### PR DESCRIPTION
If things go wrong, directory got deleted, or symlinks won't work on that version of bash on Windows, lets give users a last ray of hope and enable them to continue using the tool.