### PR TITLE
Fix off-by-one diff range error

### DIFF
--- a/diff-tools/class-git-patch-checker.php
+++ b/diff-tools/class-git-patch-checker.php
@@ -32,10 +32,10 @@ class Git_Patch_Checker {
 			}
 			if ( preg_match( '#^@@ -(\d+)(?:,(\d+))? \+(?P<line_number>\d+)(?:,(?P<line_count>\d+))? @@#', $line, $matches ) ) {
 				if ( empty( $matches['line_count'] ) ) {
-					$matches['line_count'] = 0;
+					$matches['line_count'] = 1;
 				}
 				$start_line = intval( $matches['line_number'] );
-				$end_line = intval( $matches['line_number'] ) + intval( $matches['line_count'] );
+				$end_line = intval( $matches['line_number'] ) + max( 0, intval( $matches['line_count'] ) - 1 );
 				$file_path = $current_file_path;
 				$ranges[] = compact( 'file_path', 'start_line', 'end_line' );
 			}


### PR DESCRIPTION
The diff range is calculated with one line too long. Let's look at two unified diff outputs with no context lines:

```diff
diff --git c/diff-tools/class-git-patch-checker.php w/diff-tools/class-git-patch-checker.php
index 2fb83da..40661db 100644
--- c/diff-tools/class-git-patch-checker.php
+++ w/diff-tools/class-git-patch-checker.php
@@ -35 +35 @@ class Git_Patch_Checker {
-					$matches['line_count'] = 0;
+					$matches['line_count'] = 1;
```
```
$ git diff --unified=0 | php diff-tools/parse-diff-ranges.php
w/diff-tools/class-git-patch-checker.php:35-35
```

This is correct. `@@ -35 +35 @@` is equivalent to `@@ -35,1 +35,1 @@` which means one line is affected. ["The second number is chunk size in that file; it and the comma are omitted if the chunk size is 1."](http://www.artima.com/weblogs/viewpost.jsp?thread=164293)

Internally, though, this is represented as if the omitted chunk size is an equal of 0, which shows problematic in the following example:

```diff
diff --git c/diff-tools/class-git-patch-checker.php w/diff-tools/class-git-patch-checker.php
index 40661db..8784412 100644
--- c/diff-tools/class-git-patch-checker.php
+++ w/diff-tools/class-git-patch-checker.php
@@ -35 +35,2 @@ class Git_Patch_Checker {
-                                       $matches['line_count'] = 1;
+                                       $matches['line_count'] = 0;
+
```

(I just added and extra line here.)

```
$ git diff --unified=0 | php diff-tools/parse-diff-ranges.php
w/diff-tools/class-git-patch-checker.php:35-37
```

This is wrong, only lines 35 and 36 are changed in the new file. `35,2` means that from line 35 on, two lines are changed. That is line 35 and 36. The range 35 to 37 would mean that 3 lines are affected.

My patch changes the interpretation of a missing affected line indication (first case), subtracts 1 from the line number to correctly determine the affected lines, and adds a safeguard (`max()`) to avoid any problems with diffs that should have a `,0` as line range.
