### PR TITLE
Don’t assume that pre-commit is in dev-lib/pre-commit

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -595,8 +595,9 @@ function run_phpunit_local {
 			fi
 
 			if [ ! -z "$ABSOLUTE_VAGRANT_PATH" ]; then
+				VAGRANT_DEV_LIB_PATH=$ABSOLUTE_VAGRANT_PATH${DEV_LIB_PATH:${#PROJECT_DIR}}
 				echo "Running phpunit in Vagrant"
-				vagrant ssh -c "cd $ABSOLUTE_VAGRANT_PATH && export DIFF_BASE=$DIFF_BASE && export DIFF_HEAD=$DIFF_HEAD && export DEV_LIB_ONLY=phpunit && dev-lib/pre-commit"
+				vagrant ssh -c "cd $ABSOLUTE_VAGRANT_PATH && export DIFF_BASE=$DIFF_BASE && export DIFF_HEAD=$DIFF_HEAD && export DEV_LIB_ONLY=phpunit && $VAGRANT_DEV_LIB_PATH/pre-commit"
 			elif command -v vassh >/dev/null 2>&1; then
 				echo "Running phpunit in vagrant via vassh..."
 				vassh phpunit $( if [ -n "$PHPUNIT_CONFIG" ]; then echo -c "$PHPUNIT_CONFIG"; fi )

--- a/pre-commit
+++ b/pre-commit
@@ -10,6 +10,8 @@ if [ -L "$0" ]; then
 	else
 		DEV_LIB_PATH=$( dirname $( readlink "$0" ) )
 	fi
+elif [ -f "$0" ]; then
+	DEV_LIB_PATH=$( dirname "$0" )
 else
 	DEV_LIB_PATH=dev-lib
 fi


### PR DESCRIPTION
The path to `pre-commit` is hard-coded as `dev-lib/pre-commit` when running inside Vagrant.

This builds the correct path to dev-lib by combining `$ABSOLUTE_VAGRANT_PATH` and a modified `$DEV_LIB_PATH` with respect to the `$PROJECT_DIR`:

```
VAGRANT_DEV_LIB_PATH=$ABSOLUTE_VAGRANT_PATH${DEV_LIB_PATH:${#PROJECT_DIR}}
```