### PR TITLE
Add travis notifications config to email only on change to failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 
+notifications:
+    email:
+        on_success: never
+        on_failure: change
+
 language:
     - php
     - node_js


### PR DESCRIPTION
Props WP-CLI: https://github.com/wp-cli/wp-cli/blob/feccde99a7bd45f85de2aff6e4329409ea4f6985/templates/plugin-travis.mustache#L3-L6