### PR TITLE
Use node v4 in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - WP_VERSION=trunk WP_MULTISITE=1
 
 install:
-    - nvm install 4 && nvm use 4
+    - nvm install 6 && nvm use 6
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
     - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - WP_VERSION=trunk WP_MULTISITE=1
 
 install:
+    - nvm install 4 && nvm use 4
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
     - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi


### PR DESCRIPTION
ESLint requires a more modern version of Node than Travis runs by default.