### PR TITLE
Ensure that linter configs committed as symlinks are preserved

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -276,7 +276,11 @@ function set_environment_variables {
 		# Make sure linter configs get copied linting directory since upsearch is relative.
 		for linter_file in .jshintrc .jshintignore .jscsrc .jscs.json .eslintignore .eslintrc phpcs.ruleset.xml ruleset.xml; do
 			if git ls-files "$linter_file" --error-unmatch > /dev/null 2>&1; then
-				git show :"$linter_file" > "$LINTING_DIRECTORY/$linter_file";
+				if [ -L $linter_file ]; then
+					ln -fs $(git show :"$linter_file") "$LINTING_DIRECTORY/$linter_file"
+				else
+					git show :"$linter_file" > "$LINTING_DIRECTORY/$linter_file";
+				fi
 			fi
 		done
 		if [ -e "$LINTING_DIRECTORY/$JSHINT_IGNORE" ]; then


### PR DESCRIPTION
This fixes an issue where I found that ESLint was failing to run at all because it could not find a valid `.eslintrc` when it was a symlink because `git show` was causing the path to be printed to a regular file instead of creating a symlink.