### PR TITLE
Only print files to check if the scope isn't all

### DIFF
--- a/travis.script.sh
+++ b/travis.script.sh
@@ -3,7 +3,9 @@
 set -e
 
 echo "## Checking files, scope $CHECK_SCOPE:"
-cat "$TEMP_DIRECTORY/paths-scope"
+if [[ $CHECK_SCOPE != "all" ]]; then
+	cat "$TEMP_DIRECTORY/paths-scope"
+fi
 echo
 
 check_execute_bit


### PR DESCRIPTION
There's no need to print out the files to check if we're checking all of them.