### PR TITLE
Skip running composer install if vendor dir already populated

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -462,7 +462,7 @@ function install_tools {
 	fi
 
 	# Install Composer
-	if [ -e composer.json ] && check_should_execute 'composer'; then
+	if [ -e composer.json ] && check_should_execute 'composer' && [ $( ls vendor | wc -l ) == 0 ]; then
 		if [ "$( type -t composer )" == '' ]; then
 			(
 				cd "$TEMP_TOOL_PATH"


### PR DESCRIPTION
When the `vendor` directory is cached by Travis, this results in a huge time savings:

![image](https://cloud.githubusercontent.com/assets/134745/23338327/caa57c7c-fbbc-11e6-92b0-b070692651df.png)

It also improves `pre-commit` performance since Composer is not invoked each time.