### PR TITLE
Fetch TRAVIS_BRANCH for comparison when not locally available

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -57,6 +57,13 @@ function set_environment_variables {
 
 	if [ "$TRAVIS" == true ]; then
 		if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
+
+			# Make sure the remote branch is fetched.
+			if [[ -z "$DIFF_BASE" ]] && ! git rev-parse --verify --quiet "$TRAVIS_BRANCH"; then
+				git fetch origin "$TRAVIS_BRANCH"
+				git branch "$TRAVIS_BRANCH" FETCH_HEAD
+			fi
+
 			DIFF_BASE=${DIFF_BASE:-$TRAVIS_BRANCH}
 		else
 			DIFF_BASE=${DIFF_BASE:-$TRAVIS_COMMIT^}


### PR DESCRIPTION
This fixes an issue when doing a PR from one branch into another branch, other than `master`. It may also fix the infamous “Invalid symmetric difference expression” error.