### PR TITLE
Remove doubled install_tools; trim whitespace for metadata values in parsed readme.txt

### DIFF
--- a/class-wordpress-readme-parser.php
+++ b/class-wordpress-readme-parser.php
@@ -44,7 +44,7 @@ class WordPress_Readme_Parser {
 				throw new Exception( "Parse error in $metadatum" );
 			}
 			list( $name, $value )  = array_slice( $metadataum_matches, 1, 2 );
-			$this->metadata[ $name ] = $value;
+			$this->metadata[ $name ] = trim( $value );
 		}
 		$this->metadata['Contributors'] = array_filter( preg_split( '/\s*,\s*/', $this->metadata['Contributors'] ) );
 		$this->metadata['Tags'] = array_filter( preg_split( '/\s*,\s*/', $this->metadata['Tags'] ) );

--- a/travis.install.sh
+++ b/travis.install.sh
@@ -20,6 +20,5 @@ if [[ ! -z "$PHPUNIT_VERSION" ]]; then
   fi
 fi
 
-install_tools
 set_environment_variables
 install_tools


### PR DESCRIPTION
See https://github.com/xwp/wp-dev-lib/pull/221#pullrequestreview-27472581