### PR TITLE
Raise ESLint Complexity level to 8.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
 		"accessor-pairs": [2],
 		"block-scoped-var": [2],
 		"callback-return": [2],
-		"complexity": [2, 3],
+		"complexity": [2, 8],
 		"consistent-return": [2],
 		"consistent-this": [2, "self"],
 		"constructor-super": [2],


### PR DESCRIPTION
While a complexity level of `3` for our projects seems a bit strict, the default level of `20` also seems too lenient. Personally, I think a complexity level of `8` (possibly even `6`) should allow you to accomplish your task, so let's raise it just a little.