### PR TITLE
Introduce DEFAULT_BASE_BRANCH environment var to fix diff checking on branch builds

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -56,18 +56,20 @@ function set_environment_variables {
 	CHECK_SCOPE=${CHECK_SCOPE:-patches} # 'all', 'changed-files', 'patches'
 
 	if [ "$TRAVIS" == true ]; then
+		GITHUB_DEFAULT_BRANCH=${GITHUB_DEFAULT_BRANCH:-master}
 		if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
-
-			# Make sure the remote branch is fetched.
-			if [[ -z "$DIFF_BASE" ]] && ! git rev-parse --verify --quiet "$TRAVIS_BRANCH"; then
-				git fetch origin "$TRAVIS_BRANCH"
-				git branch "$TRAVIS_BRANCH" FETCH_HEAD
-			fi
-
-			DIFF_BASE=${DIFF_BASE:-$TRAVIS_BRANCH}
+			DIFF_BASE_BRANCH=$TRAVIS_BRANCH
 		else
-			DIFF_BASE=${DIFF_BASE:-$TRAVIS_COMMIT^}
+			DIFF_BASE_BRANCH=$GITHUB_DEFAULT_BRANCH
 		fi
+
+		# Make sure the remote branch is fetched.
+		if [[ -z "$DIFF_BASE" ]] && ! git rev-parse --verify --quiet "$DIFF_BASE_BRANCH" > /dev/null; then
+			git fetch origin "$DIFF_BASE_BRANCH"
+			git branch "$DIFF_BASE_BRANCH" FETCH_HEAD
+		fi
+
+		DIFF_BASE=${DIFF_BASE:-$DIFF_BASE_BRANCH}
 		DIFF_HEAD=${DIFF_HEAD:-$TRAVIS_COMMIT}
 	else
 		DIFF_BASE=${DIFF_BASE:-HEAD}

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -56,11 +56,11 @@ function set_environment_variables {
 	CHECK_SCOPE=${CHECK_SCOPE:-patches} # 'all', 'changed-files', 'patches'
 
 	if [ "$TRAVIS" == true ]; then
-		GITHUB_DEFAULT_BRANCH=${GITHUB_DEFAULT_BRANCH:-master}
+		DEFAULT_BASE_BRANCH=${DEFAULT_BASE_BRANCH:-master}
 		if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
 			DIFF_BASE_BRANCH=$TRAVIS_BRANCH
 		else
-			DIFF_BASE_BRANCH=$GITHUB_DEFAULT_BRANCH
+			DIFF_BASE_BRANCH=$DEFAULT_BASE_BRANCH
 		fi
 
 		# Make sure the remote branch is fetched.

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -36,6 +36,7 @@ function set_environment_variables {
 	PROJECT_SLUG=${PROJECT_SLUG:-$( basename "$PROJECT_DIR" | sed 's/^wp-//' )}
 	PATH_INCLUDES=${PATH_INCLUDES:-./}
 	PATH_EXCLUDES_PATTERN=${PATH_EXCLUDES_PATTERN:-'^(.*/)?(vendor|bower_components|node_modules)/.*'}
+	DEFAULT_BASE_BRANCH=${DEFAULT_BASE_BRANCH:-master}
 
 	if [ -z "$PROJECT_TYPE" ]; then
 		if [ -e style.css ]; then
@@ -56,7 +57,6 @@ function set_environment_variables {
 	CHECK_SCOPE=${CHECK_SCOPE:-patches} # 'all', 'changed-files', 'patches'
 
 	if [ "$TRAVIS" == true ]; then
-		DEFAULT_BASE_BRANCH=${DEFAULT_BASE_BRANCH:-master}
 		if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
 			DIFF_BASE_BRANCH=$TRAVIS_BRANCH
 		else

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ You may customize the behavior of the `.travis.yml` and `pre-commit` hook by
 specifying a `.dev-lib` (formerly `.ci-env.sh`) Bash script in the root of the repo, for example:
 
 ```bash
+GITHUB_DEFAULT_BRANCH=develop
 PHPCS_GITHUB_SRC=xwp/PHP_CodeSniffer
 PHPCS_GIT_TREE=phpcs-patch
 PHPCS_IGNORE='tests/*,includes/vendor/*' # See also PATH_INCLUDES below
@@ -139,7 +140,7 @@ PATH_INCLUDES="docroot/wp-content/plugins/acme-* docroot/wp-content/themes/acme-
 CHECK_SCOPE=patches
 ```
 
-The `PATH_INCLUDES` is especially useful when the dev-lib is used in the context of an entire site, so you can target just the themes and plugins that you're responsible for. For *excludes*, you can specify a `PHPCS_IGNORE` var and override the `.jshintignore` (it would be better to have a `PATH_EXCLUDES` as well).
+Set `GITHUB_DEFAULT_BRANCH` to be whatever your default branch is in GitHub; this is use when doing diff-checks on changes in a branch build on Travis CI. The `PATH_INCLUDES` is especially useful when the dev-lib is used in the context of an entire site, so you can target just the themes and plugins that you're responsible for. For *excludes*, you can specify a `PHPCS_IGNORE` var and override the `.jshintignore`; there is a `PATH_EXCLUDES_PATTERN` as well.
 
 ## Pre-commit tips
 

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ You may customize the behavior of the `.travis.yml` and `pre-commit` hook by
 specifying a `.dev-lib` (formerly `.ci-env.sh`) Bash script in the root of the repo, for example:
 
 ```bash
-GITHUB_DEFAULT_BRANCH=develop
+DEFAULT_BASE_BRANCH=develop
 PHPCS_GITHUB_SRC=xwp/PHP_CodeSniffer
 PHPCS_GIT_TREE=phpcs-patch
 PHPCS_IGNORE='tests/*,includes/vendor/*' # See also PATH_INCLUDES below
@@ -140,7 +140,7 @@ PATH_INCLUDES="docroot/wp-content/plugins/acme-* docroot/wp-content/themes/acme-
 CHECK_SCOPE=patches
 ```
 
-Set `GITHUB_DEFAULT_BRANCH` to be whatever your default branch is in GitHub; this is use when doing diff-checks on changes in a branch build on Travis CI. The `PATH_INCLUDES` is especially useful when the dev-lib is used in the context of an entire site, so you can target just the themes and plugins that you're responsible for. For *excludes*, you can specify a `PHPCS_IGNORE` var and override the `.jshintignore`; there is a `PATH_EXCLUDES_PATTERN` as well.
+Set `DEFAULT_BASE_BRANCH` to be whatever your default branch is in GitHub; this is use when doing diff-checks on changes in a branch build on Travis CI. The `PATH_INCLUDES` is especially useful when the dev-lib is used in the context of an entire site, so you can target just the themes and plugins that you're responsible for. For *excludes*, you can specify a `PHPCS_IGNORE` var and override the `.jshintignore`; there is a `PATH_EXCLUDES_PATTERN` as well.
 
 ## Pre-commit tips
 


### PR DESCRIPTION
Fixes #197.

The root of the problem for why branch builds would pass when PR builds would fail, and why the branch build would show fewer changed files than the PR build (when `CHECK_SCOPE` is `patches` or `changed-files`), is due to this line:

```bash
DIFF_BASE=${DIFF_BASE:-$TRAVIS_COMMIT^}
```

Essentially the branch build was only diffing with the previous commit on the branch. As such, the change here is to suggest a `GITHUB_DEFAULT_BRANCH` environment variable to define what the default branch us for the repo on GitHub (since it doesn't seem to be among the environment vars that Travis exposes), which also assumes that the default branch is going to be the target of the pull request.

I'm not 100% certain this is the right approach, but it seems somewhat better than only comparing with the parent commit.