### PR TITLE
Add ability to define phpunit version, falling back to 5.7 

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -394,8 +394,9 @@ function install_tools {
 	# Install PHP tools.
 	if [ -s "$TEMP_DIRECTORY/paths-scope-php" ]; then
 		if [ -z "$( type -t phpunit )" ] && check_should_execute 'phpunit'; then
-			echo "Downloading PHPUnit phar"
-			download https://phar.phpunit.de/phpunit.phar "$TEMP_TOOL_PATH/phpunit"
+			PHPUNIT_VERSION=${PHPUNIT_VERSION:-5.7}
+			echo "Downloading PHPUnit $PHPUNIT_VERSION phar"
+			download https://phar.phpunit.de/phpunit-$PHPUNIT_VERSION.phar "$TEMP_TOOL_PATH/phpunit"
 			chmod +x "$TEMP_TOOL_PATH/phpunit"
 		fi
 


### PR DESCRIPTION
Travis install script has been updated to use 5.7, but not the local install within check-diff.sh, this adds the ability to define PHPUNIT_VERSION , and falls back to 5.7 if not defined.