### PR TITLE
Use phar for PHPCS 2.8.1 since builds are breaking in PHPCS 3.0.0

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -102,7 +102,8 @@ function set_environment_variables {
 		shift # past argument or value
 	done
 
-	PHPCS_PHAR_URL=https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+	# TODO: Change back to https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar once 3.x compat is done.
+	PHPCS_PHAR_URL=https://github.com/squizlabs/PHP_CodeSniffer/blob/700168ede59d6a7d45fc4a2feefde1d156eb4573/phpcs.phar?raw=true
 	PHPCS_RULESET_FILE=$( upsearch phpcs.ruleset.xml )
 	PHPCS_IGNORE=${PHPCS_IGNORE:-'vendor/*'}
 	PHPCS_GIT_TREE=${PHPCS_GIT_TREE:-master}


### PR DESCRIPTION
The new 3.0.0 release of PHP_CodeSniffer has some back-compat problems as can be seen in these Travis build errors:

* PHP 5.2 incompatibility: https://travis-ci.org/xwp/wp-core-media-widgets/jobs/228594208#L355
* WPCS incompatibility: https://travis-ci.org/xwp/wp-core-media-widgets/jobs/228594210#L382

For the latter, see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718

For a temporary fix, we can temporarily revert back to PHPCS 2.8.1.