### PR TITLE
Set Travis dist to precise for PHP≤5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 
 notifications:
   email:
@@ -16,8 +17,8 @@ language:
   - node_js
 
 php:
-  - 5.4
-  - 5.5
+  - 5.2
+  - 5.3
   - 5.6
   - 7.0
 


### PR DESCRIPTION
If you get an error in a Travis build like:

```
$ phpenv global 5.3
rbenv: version `5.3' not installed
```

It's because PHP 5.2 and PHP 5.3 are not supported on Travis's `trusty` distro, which is becoming the default. To keep using these, explicitly using the `precise` distro ensures that these versions of PHP will continue to be available.