### PR TITLE
Exclude only the git hooks

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -703,7 +703,7 @@ function run_phpunit_travisci {
 
 		# Rsync the files into the right location
 		mkdir -p "$INSTALL_PATH"
-		rsync -a $(verbose_arg) --exclude .git --delete "$PROJECT_DIR/" "$INSTALL_PATH/"
+		rsync -a $(verbose_arg) --exclude .git/hooks --delete "$PROJECT_DIR/" "$INSTALL_PATH/"
 		cd "$INSTALL_PATH"
 
 		echo "Location: $INSTALL_PATH"
@@ -712,7 +712,7 @@ function run_phpunit_travisci {
 
 		# Rsync the files into the right location
 		mkdir -p "$INSTALL_PATH"
-		rsync -a $(verbose_arg) --exclude .git --delete "$PROJECT_DIR/" "$INSTALL_PATH/"
+		rsync -a $(verbose_arg) --exclude .git/hooks --delete "$PROJECT_DIR/" "$INSTALL_PATH/"
 		cd "$INSTALL_PATH"
 
 		# Clone the theme dependencies (i.e. plugins) into the plugins directory


### PR DESCRIPTION
Excluding the entire `.git` cause a fatal error when `php-coveralls` is trying to check the branch.

```
#0 /tmp/wordpress/src/wp-content/plugins/social-manager/vendor/satooshi/php-coveralls/src/Satooshi/Component/System/Git/GitCommand.php(32): Satooshi\Component\System\SystemCommand->executeCommand('git branch')
```

Example of failed build: https://travis-ci.org/ninecodes/wp-social-manager/jobs/266361042