### PR TITLE
Allow WP_CONTENT_DIR to be set using environment variables.

### DIFF
--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -32,11 +32,11 @@ if ( empty( $_tests_dir ) ) {
 }
 
 // Relative path to Core tests directory.
-if ( ! file_exists( $_tests_dir . '/includes/' ) ) {
+if ( ! is_dir( $_tests_dir . '/includes/' ) ) {
 	$_tests_dir = '../../../../tests/phpunit';
 }
 
-if ( ! file_exists( $_tests_dir . '/includes/' ) ) {
+if ( ! is_dir( $_tests_dir . '/includes/' ) ) {
 	trigger_error( 'Unable to locate wordpress-tests-lib', E_USER_ERROR );
 }
 require_once $_tests_dir . '/includes/functions.php';

--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -1,10 +1,19 @@
 <?php
-// Determine if we should update the content and plugin paths.
-if ( file_exists( dirname( __DIR__ ) . '/wp-load.php' ) ) {
-	define( 'WP_CONTENT_DIR', dirname( __DIR__ ) . '/wp-content/' );
-} else if ( file_exists( '../../../wp-content' ) ) {
-	define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content/' );
+
+/**
+ * Determine if we should update the content and plugin paths.
+ */
+if ( ! defined( 'WP_CONTENT_DIR' ) && getenv( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', getenv( 'WP_CONTENT_DIR' ) );
 }
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	if ( file_exists( dirname( __DIR__ ) . '/wp-load.php' ) ) {
+		define( 'WP_CONTENT_DIR', dirname( __DIR__ ) . '/wp-content/' );
+	} else if ( file_exists( '../../../wp-content' ) ) {
+		define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content/' );
+	}
+}
+
 if ( defined( 'WP_CONTENT_DIR' ) && ! defined( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . 'plugins/' );
 }


### PR DESCRIPTION
I was using Mark Jaquith's [WordPress skeleton](https://markjaquith.wordpress.com/2012/05/26/wordpress-skeleton/) so the hardcoded `/wp-content` was not workable.

Also, while I was at it I updated two uses of `file_exists()` to the more accurate `is_dir()`.