### PR TITLE
Add environment variable for skipping paths-scope printing; suppress full npm install output

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -415,7 +415,7 @@ function install_tools {
 
 	# Install Node packages.
 	if [ -e package.json ] && [ $( ls node_modules | wc -l ) == 0 ]; then
-		npm install
+		npm install --loglevel error > /dev/null
 	fi
 
 	# Install Composer

--- a/travis.script.sh
+++ b/travis.script.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "## Checking files, scope $CHECK_SCOPE:"
-if [[ $CHECK_SCOPE != "all" ]]; then
+if [[ -z $SKIP_ECHO_PATHS_SCOPE ]] && [[ $CHECK_SCOPE != "all" ]]; then
 	cat "$TEMP_DIRECTORY/paths-scope"
 fi
 echo


### PR DESCRIPTION
When `patches` is the `CHECK_SCOPE` (the default) the list can be very long and muddy up the Travis log. By adding the following to `.dev-lib` you can skip this:

```bash
SKIP_ECHO_PATHS_SCOPE=1
```