### PR TITLE
Add Composer Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 codecept.phar
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "xwp/wp-dev-lib",
+  "description": "Common code used during development of WordPress plugins and themes",
+  "license": "MIT",
+  "homepage": "https://github.com/xwp/wp-dev-lib",
+  "authors": [
+    {
+      "name": "Weston Ruter",
+      "email": "weston@xwp.co",
+      "homepage": "https://weston.ruter.net"
+    },
+    {
+      "name": "XWP",
+      "email": "engage@xwp.co",
+      "homepage": "https://xwp.co"
+    }
+  ],
+  "keywords": [
+    "WordPress"
+  ],
+  "support": {
+    "issues": "https://github.com/xwp/wp-dev-lib/issues",
+    "source": "https://github.com/xwp/wp-dev-lib"
+  },
+  "require": {}
+}

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,16 @@ cd ~/Shared/dev-lib
 ./install-shared-pre-commit-hook.sh ~/Projects/wordpress
 ```
 
+### Install via Composer
+
+Add `wp-dev-lib` as a [Composer](https://getcomposer.org) developer dependancy to your project:
+
+```bash
+composer require xwp/wp-dev-lib:dev-master --dev
+```
+
+which will place this library under `vendor/xwp/wp-dev-lib`.
+
 ## Travis CI
 
 Copy the [`.travis.yml`](.travis.yml) file into the root of your repo:


### PR DESCRIPTION
Fixes #272.

- [x] Add basic `composer.json` to support installing `wp-dev-lib` as a Composer developer dependancy.
- [x] Update `readme.md` to indicate Composer support.

We [already support](https://github.com/xwp/wp-dev-lib/blob/master/package.json) `npm require xwp/wp-dev-lib --save-dev` and adding support for Composer would further improve the usability of this tool. For example, [WordPress coding standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) also support [installing using Composer](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installing-wpcs-as-a-dependency).