### PR TITLE
Include Composer vendor in the linting directory

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -310,7 +310,7 @@ function set_environment_variables {
 		fi
 
 		# Make sure that all of the dev-lib is copied to the linting directory in case any configs extend instead of symlink.
-		mkdir -p $LINTING_DIRECTORY/dev-lib
+		mkdir -p "$LINTING_DIRECTORY/dev-lib"
 		rsync -avzq --exclude .git "$DEV_LIB_PATH/" "$LINTING_DIRECTORY/dev-lib/"
 
 		# Use node_modules from actual directory (create node_modules symlink even if it won't be created).

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -313,6 +313,16 @@ function set_environment_variables {
 		mkdir -p "$LINTING_DIRECTORY/dev-lib"
 		rsync -avzq --exclude .git "$DEV_LIB_PATH/" "$LINTING_DIRECTORY/dev-lib/"
 
+		if [ -e "$PROJECT_DIR/composer.json" ] && command -v composer >/dev/null 2>&1; then
+			# Get the Composer vendor directory.
+			COMPOSER_VENDOR_DIR=$(composer config vendor-dir)
+
+			# Ensure the Composer vendor directory is available in case there are dev tools inside.
+			if [ -n "$COMPOSER_VENDOR_DIR" ] && [ -d "$PROJECT_DIR/$COMPOSER_VENDOR_DIR" ]; then
+				ln -sf "$PROJECT_DIR/$COMPOSER_VENDOR_DIR" "$LINTING_DIRECTORY/$COMPOSER_VENDOR_DIR"
+			fi
+		fi
+
 		# Use node_modules from actual directory (create node_modules symlink even if it won't be created).
 		if [ -e "$PROJECT_DIR/package.json" ]; then
 			if [ -e "$LINTING_DIRECTORY/node_modules" ]; then


### PR DESCRIPTION
Fixes #274 and #236.

Similar to symlinking `node_modules` we also link the `vendor` directory.