### PR TITLE
Remove erroneous trailing slashes from WP_CONTENT_DIR and WP_PLUGIN_DIR

### DIFF
--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -8,14 +8,14 @@ if ( ! defined( 'WP_CONTENT_DIR' ) && getenv( 'WP_CONTENT_DIR' ) ) {
 }
 if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 	if ( file_exists( dirname( __DIR__ ) . '/wp-load.php' ) ) {
-		define( 'WP_CONTENT_DIR', dirname( __DIR__ ) . '/wp-content/' );
+		define( 'WP_CONTENT_DIR', dirname( __DIR__ ) . '/wp-content' );
 	} else if ( file_exists( '../../../wp-content' ) ) {
-		define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content/' );
+		define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content' );
 	}
 }
 
 if ( defined( 'WP_CONTENT_DIR' ) && ! defined( 'WP_PLUGIN_DIR' ) ) {
-	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . 'plugins/' );
+	define( 'WP_PLUGIN_DIR', rtrim( WP_CONTENT_DIR, '/' ) . '/plugins' );
 }
 
 if ( file_exists( __DIR__ . '/../phpunit-plugin-bootstrap.project.php' ) ) {


### PR DESCRIPTION
Note how trailing slashes should not be included:

* https://github.com/WordPress/wordpress-develop/blob/506a99ef30167563271042d345917bb306ec0aa6/src/wp-includes/default-constants.php#L66-L68
* https://github.com/WordPress/wordpress-develop/blob/506a99ef30167563271042d345917bb306ec0aa6/src/wp-includes/default-constants.php#L155-L157