### PR TITLE
Fix calculation of realpath from phpcs paths

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -925,7 +925,7 @@ function lint_php_files {
 				if [ ! -s "$TEMP_DIRECTORY/phpcs-report" ]; then
 					return 1
 				elif [ "$CHECK_SCOPE" == 'patches' ]; then
-					cat "$TEMP_DIRECTORY/phpcs-report" | php "$DEV_LIB_PATH/diff-tools/filter-report-for-patch-ranges.php" "$TEMP_DIRECTORY/paths-scope-php" | cut -c$( expr ${#LINTING_DIRECTORY} + 2 )-
+					cat "$TEMP_DIRECTORY/phpcs-report" | php "$DEV_LIB_PATH/diff-tools/filter-report-for-patch-ranges.php" "$TEMP_DIRECTORY/paths-scope-php" | cut -c$( expr ${#LINTING_DIRECTORY} + 1 )-
 					phpcs_status="${PIPESTATUS[1]}"
 					if [[ $phpcs_status != 0 ]]; then
 						return $phpcs_status

--- a/diff-tools/filter-report-for-patch-ranges.php
+++ b/diff-tools/filter-report-for-patch-ranges.php
@@ -44,6 +44,13 @@ while ( $line = fgets( STDIN ) ) {
 		continue;
 	}
 	$file_path = realpath( $matches['file_path'] );
+	if ( ! $file_path ) {
+		$file_path = realpath( '/' . $matches['file_path'] );
+	}
+	if ( ! $file_path ) {
+		fwrite( STDERR, sprintf( "Unable to find realpath for: %s", $matches['file_path'] ) );
+		exit( 3 );
+	}
 	if ( ! array_key_exists( $file_path, $parsed_diff_ranges ) ) {
 		continue;
 	}


### PR DESCRIPTION
Fixes issue:

> Warning: array_key_exists(): The first argument should be either a string or an integer in ...wp-dev-lib/diff-tools/filter-report-for-patch-ranges.php on line 47

For some reason `phpcs --report-emacs` is not including the initial slash in the current version.