### PR TITLE
Improve example PHPCS ruleset

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,18 +2,31 @@
 <ruleset name="WordPress Coding Standards for Plugins">
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
-	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress-Docs" />
 
 	<!--
+	<config name="minimum_supported_wp_version" value="4.6"/>
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" value="example,default" />
+			<property name="text_domain" type="array">
+				<element value="example"/>
+				<element value="default"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="example"/>
+			</property>
 		</properties>
 	</rule>
 	-->
 
-	<rule ref="PHPCompatibility"/>
+	<rule ref="PHPCompatibilityWP"/>
 	<config name="testVersion" value="5.2-"/>
 
 	<arg name="extensions" value="php"/>

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ echo 'node_modules' >> .gitignore
 composer init # if you don't have a composer.json already
 composer require php '>=5.2' # increase this if you need
 composer require --dev "wp-coding-standards/wpcs=*"
-composer require --dev "wimg/php-compatibility=*"
+composer require --dev "phpcompatibility/phpcompatibility-wp=*"
 composer require --dev dealerdirect/phpcodesniffer-composer-installer
 echo 'vendor' >> .gitignore
 


### PR DESCRIPTION
* Add two more WPCS properties/directives which are highly recommended to be set for best sniff results.
* Recommend using `WordPress-Extra` rather than `WordPress-Core` for plugins as it contains a broader set of sniffs.
* Use the PHPCS 3.3.0+ array format for array properties.
* Use the PHPCompatibilityWP standard to check for PHP cross-version compatibility instead of PHPCompatibility. The PHPCompatibilityWP standard takes back-fills/polyfills included in WP into account to prevent false positives.