### PR TITLE
Fix unit tests with WordPress 5.0

### DIFF
--- a/check-diff.sh
+++ b/check-diff.sh
@@ -556,6 +556,10 @@ function install_wp {
 
 	svn export -q "$SVN_URL" "$WP_CORE_DIR"
 
+	# Add workaround for running PHPUnit tests from source by touching built files.
+	mkdir -p $WP_CORE_DIR/src/wp-includes/css/dist/block-library/
+	touch $WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css
+
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/src/wp-content/db.php"
 }
 

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -546,7 +546,7 @@ function install_wp {
 	elif [ "$WP_VERSION" == 'latest' ]; then
 		local TAG=$( svn ls https://develop.svn.wordpress.org/tags | tail -n 1 | sed 's:/$::' )
 		local SVN_URL="https://develop.svn.wordpress.org/tags/$TAG/"
-	elif [[ "$WP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	elif [[ "$WP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
 		local SVN_URL="https://develop.svn.wordpress.org/branches/$WP_VERSION/"
 	else
 		local SVN_URL="https://develop.svn.wordpress.org/tags/$WP_VERSION/"

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -546,6 +546,8 @@ function install_wp {
 	elif [ "$WP_VERSION" == 'latest' ]; then
 		local TAG=$( svn ls https://develop.svn.wordpress.org/tags | tail -n 1 | sed 's:/$::' )
 		local SVN_URL="https://develop.svn.wordpress.org/tags/$TAG/"
+	elif [[ "$WP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+		local SVN_URL="https://develop.svn.wordpress.org/branches/$WP_VERSION/"
 	else
 		local SVN_URL="https://develop.svn.wordpress.org/tags/$WP_VERSION/"
 	fi

--- a/check-diff.sh
+++ b/check-diff.sh
@@ -547,6 +547,7 @@ function install_wp {
 		local TAG=$( svn ls https://develop.svn.wordpress.org/tags | tail -n 1 | sed 's:/$::' )
 		local SVN_URL="https://develop.svn.wordpress.org/tags/$TAG/"
 	elif [[ "$WP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+		# Use the release branch if no patch version supplied. This is useful to keep testing the latest minor version.
 		local SVN_URL="https://develop.svn.wordpress.org/branches/$WP_VERSION/"
 	else
 		local SVN_URL="https://develop.svn.wordpress.org/tags/$WP_VERSION/"
@@ -557,8 +558,8 @@ function install_wp {
 	svn export -q "$SVN_URL" "$WP_CORE_DIR"
 
 	# Add workaround for running PHPUnit tests from source by touching built files.
-	mkdir -p $WP_CORE_DIR/src/wp-includes/css/dist/block-library/
-	touch $WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css
+	mkdir -p "$WP_CORE_DIR/src/wp-includes/css/dist/block-library"
+	touch "$WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css"
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/src/wp-content/db.php"
 }

--- a/phpunit-plugin-bootstrap.php
+++ b/phpunit-plugin-bootstrap.php
@@ -72,6 +72,15 @@ function xwp_filter_active_plugins_for_phpunit( $active_plugins ) {
 	} else if ( defined( 'WP_TEST_ACTIVATED_PLUGINS' ) ) {
 		$forced_active_plugins = preg_split( '/\s*,\s*/', WP_TEST_ACTIVATED_PLUGINS );
 	}
+
+	// Prevent loading feature plugins that have been merged.
+	if ( file_exists( ABSPATH . 'wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php' ) ) {
+		$forced_active_plugins = array_diff(
+			$forced_active_plugins,
+			array( 'gutenberg/gutenberg.php' )
+		);
+	}
+
 	if ( ! empty( $forced_active_plugins ) ) {
 		foreach ( $forced_active_plugins as $forced_active_plugin ) {
 			$active_plugins[] = $forced_active_plugin;


### PR DESCRIPTION
* Test from latest core branches instead of initial major point release.
* Prevent loading Gutenberg plugin if on 5.0.

This fixes a fatal error when running tests on the 5.0 branch:

> PHP Fatal error:  Cannot declare class WP_REST_Autosaves_Controller, because the name is already in use in ...wp-content/plugins/gutenberg/lib/class-wp-rest-autosaves-controller.php on line 387