### PR TITLE
Update cache directories for Composer and NPM

### DIFF
--- a/sample-config/.travis.yml
+++ b/sample-config/.travis.yml
@@ -8,8 +8,9 @@ notifications:
 
 cache:
   directories:
-    - node_modules
-    - vendor
+    - $HOME/.composer/cache
+    - $HOME/.npm
+    - $HOME/.nvm/.cache
     - $HOME/phpunit-bin
 
 language:


### PR DESCRIPTION
Caching the `node_modules` and `vendor` directories means that Travis's cache must be cleared frequently whenever new dependencies are added. That's a pain. I noticed that Gutenberg instead has user-level NPM/Composer cache directories:

https://github.com/WordPress/gutenberg/blob/3c5fd224e4bf3b1cc8dcda0407371ec18f953f11/.travis.yml#L15-L18

This should mean that `composer install` and `npm install` should still run quick even when there are no `vendor` or `node_modules` directories, while also fixing the problem of stale dependencies being cached.