### PR TITLE
Ensure Travis badge uses correct branch

### DIFF
--- a/scripts/class-wordpress-readme-parser.php
+++ b/scripts/class-wordpress-readme-parser.php
@@ -208,7 +208,7 @@ class WordPress_Readme_Parser {
 					$badge_md .= sprintf( '[![Build Status](%1$s)](%2$s) ', $params['travis_ci_pro_badge_src'], $url );
 				}
 				if ( 'travis_ci_url' === $badge ) {
-					$badge_md .= sprintf( '[![Build Status](%1$s.svg?branch=master)](%1$s) ', $url );
+					$badge_md .= sprintf( '[![Build Status](%1$s)](%2$s) ', $params['travis_ci_badge_src'], $url );
 				}
 				if ( 'coveralls_url' === $badge ) {
 					$badge_md .= sprintf( '[![Coverage Status](%s)](%s) ', $params['coveralls_badge_src'], $url );

--- a/scripts/generate-markdown-readme
+++ b/scripts/generate-markdown-readme
@@ -95,12 +95,14 @@ try {
 			}
 		}
 		if ( file_exists( $readme_root . '/.travis.yml' ) ) {
+			$branch = isset( $env_vars['DEFAULT_BASE_BRANCH'] ) ? $env_vars['DEFAULT_BASE_BRANCH'] : 'master';
 			if ( isset( $travis_ci_pro_badge ) ) {
 				$md_args['travis_ci_pro_url'] = "https://magnum.travis-ci.com/$github_account_repo";
-				$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$travis_ci_pro_badge&branch=master";
+				$md_args['travis_ci_pro_badge_src'] = $md_args['travis_ci_pro_url'] . ".svg?token=$travis_ci_pro_badge&branch=$branch";
 			}
 			if ( ! isset( $md_args['travis_ci_pro_url'] ) ) {
 				$md_args['travis_ci_url'] = "https://travis-ci.org/$github_account_repo";
+				$md_args['travis_ci_badge_src'] = $md_args['travis_ci_url'] . ".svg?branch=$branch";
 			}
 		}
 		if ( file_exists( $readme_root . '/.coveralls.yml' ) ) {


### PR DESCRIPTION
Setting the `DEFAULT_BASE_BRANCH` does nothing for the Travis CI branch when generating the MD file. This PR fixes that for both free and pro account.