### PR TITLE
Fix Grunt badge image URL

### DIFF
--- a/scripts/class-wordpress-readme-parser.php
+++ b/scripts/class-wordpress-readme-parser.php
@@ -214,7 +214,7 @@ class WordPress_Readme_Parser {
 					$badge_md .= sprintf( '[![Coverage Status](%s)](%s) ', $params['coveralls_badge_src'], $url );
 				}
 				if ( 'grunt_url' === $badge ) {
-					$badge_md .= sprintf( '[![Built with Grunt](https://cdn.%1$s/builtwith.svg)](http://%1$s) ', $url );
+					$badge_md .= sprintf( '[![Built with Grunt](https://%1$s/cdn/builtwith.svg)](http://%1$s) ', $url );
 				}
 				if ( 'david_url' === $badge ) {
 					$badge_md .= sprintf( '[![Dependency Status](%1$s.svg)](%1$s) ', $url );


### PR DESCRIPTION
The Grunt badge image URL https://cdn.gruntjs.com/builtwith.svg is no longer working:

![image](https://user-images.githubusercontent.com/134745/55664274-a0963480-57e0-11e9-9195-559f5079d33f.png)

Apparently it has changed to https://gruntjs.com/cdn/builtwith.svg

This makes that change.