### PR TITLE
Add support for codecov badge

### DIFF
--- a/scripts/class-wordpress-readme-parser.php
+++ b/scripts/class-wordpress-readme-parser.php
@@ -190,6 +190,7 @@ class WordPress_Readme_Parser {
 			'travis_ci_pro_url',
 			'travis_ci_url',
 			'coveralls_url',
+			'codecov_url',
 			'grunt_url',
 			'david_url',
 			'david_dev_url',
@@ -212,6 +213,9 @@ class WordPress_Readme_Parser {
 				}
 				if ( 'coveralls_url' === $badge ) {
 					$badge_md .= sprintf( '[![Coverage Status](%s)](%s) ', $params['coveralls_badge_src'], $url );
+				}
+				if ( 'codecov_url' === $badge ) {
+					$badge_md .= sprintf( '[![Coverage Status](%s)](%s) ', $params['codecov_badge_src'], $url );
 				}
 				if ( 'grunt_url' === $badge ) {
 					$badge_md .= sprintf( '[![Built with Grunt](https://%1$s/cdn/builtwith.svg)](http://%1$s) ', $url );

--- a/scripts/generate-markdown-readme
+++ b/scripts/generate-markdown-readme
@@ -113,6 +113,11 @@ try {
 				$md_args['coveralls_badge_src'] .= "&service=github&t=$coveralls_badge";
 			}
 		}
+		if ( file_exists( $readme_root . '/codecov.yml' ) || file_exists( $readme_root . '/.codecov.yml' ) ) {
+			$branch = isset( $env_vars['DEFAULT_BASE_BRANCH'] ) ? $env_vars['DEFAULT_BASE_BRANCH'] : 'master';
+			$md_args['codecov_url'] = "https://codecov.io/gh/$github_account_repo";
+			$md_args['codecov_badge_src'] = "https://img.shields.io/codecov/c/github/$github_account_repo/$branch.svg";
+		}
 		if ( file_exists( $readme_root . '/Gruntfile.js' ) ) {
 			$md_args['grunt_url'] = 'gruntjs.com';
 		}


### PR DESCRIPTION
Example of change to `readme.md` when `codecov.yml` or `.codecov.yml` is present in the repo:

> ![image](https://user-images.githubusercontent.com/134745/58982795-20f9f700-878a-11e9-8815-d7cb4e5ba70f.png)

See #153.