### PR TITLE
Cleanup PHPUnit version logic

### DIFF
--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -452,12 +452,12 @@ function install_tools {
 	# Install PHP tools.
 	if [ -s "$TEMP_DIRECTORY/paths-scope-php" ]; then
 		if check_should_execute 'phpunit' && ! command -v phpunit >/dev/null 2>&1; then
-			if [ -n "$PHPUNIT_VERSION" ]; then
 				PHPUNIT_VERSION="5.7"
 
 				# Or newer depending on the PHP version.
 				if min_php_version "7.1"; then
 					PHPUNIT_VERSION="7"
+			if [ -z "$PHPUNIT_VERSION" ]; then
 				elif min_php_version "7.0"; then
 					PHPUNIT_VERSION="6"
 				fi

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -454,7 +454,7 @@ function install_tools {
 		if check_should_execute 'phpunit' && ! command -v phpunit >/dev/null 2>&1; then
 			PHPUNIT_VERSION=${PHPUNIT_VERSION:-5.7}
 			echo "Downloading PHPUnit $PHPUNIT_VERSION phar"
-			download https://phar.phpunit.de/phpunit-$PHPUNIT_VERSION.phar "$TEMP_TOOL_PATH/phpunit"
+			download "https://phar.phpunit.de/phpunit-$PHPUNIT_VERSION.phar" "$TEMP_TOOL_PATH/phpunit"
 			chmod +x "$TEMP_TOOL_PATH/phpunit"
 		fi
 

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -452,7 +452,17 @@ function install_tools {
 	# Install PHP tools.
 	if [ -s "$TEMP_DIRECTORY/paths-scope-php" ]; then
 		if check_should_execute 'phpunit' && ! command -v phpunit >/dev/null 2>&1; then
-			PHPUNIT_VERSION=${PHPUNIT_VERSION:-5.7}
+			if [ -n "$PHPUNIT_VERSION" ]; then
+				PHPUNIT_VERSION="5.7"
+
+				# Or newer depending on the PHP version.
+				if min_php_version "7.1"; then
+					PHPUNIT_VERSION="7"
+				elif min_php_version "7.0"; then
+					PHPUNIT_VERSION="6"
+				fi
+			fi
+
 			echo "Downloading PHPUnit $PHPUNIT_VERSION phar"
 			download "https://phar.phpunit.de/phpunit-$PHPUNIT_VERSION.phar" "$TEMP_TOOL_PATH/phpunit"
 			chmod +x "$TEMP_TOOL_PATH/phpunit"

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -452,14 +452,15 @@ function install_tools {
 	# Install PHP tools.
 	if [ -s "$TEMP_DIRECTORY/paths-scope-php" ]; then
 		if check_should_execute 'phpunit' && ! command -v phpunit >/dev/null 2>&1; then
-				PHPUNIT_VERSION="5.7"
-
-				# Or newer depending on the PHP version.
-				if min_php_version "7.1"; then
-					PHPUNIT_VERSION="7"
 			if [ -z "$PHPUNIT_VERSION" ]; then
-				elif min_php_version "7.0"; then
+				if ! min_php_version "7.1"; then
+					PHPUNIT_VERSION="7"
+				elif ! min_php_version "7.0"; then
 					PHPUNIT_VERSION="6"
+				elif ! min_php_version "5.6"; then
+					PHPUNIT_VERSION="5"
+				else
+					PHPUNIT_VERSION="4"
 				fi
 			fi
 

--- a/scripts/travis.install.sh
+++ b/scripts/travis.install.sh
@@ -6,25 +6,5 @@ shopt -s expand_aliases
 # TODO: We know that $DEV_LIB_PATH is _this_ directory, use that directly.
 source "$DEV_LIB_PATH/check-diff.sh"
 
-# The following should be temporary. See <https://core.trac.wordpress.org/ticket/40086>, <https://core.trac.wordpress.org/ticket/39822>.
-if check_should_execute 'phpunit'; then
-  if [[ -z "$PHPUNIT_VERSION" ]]; then
-    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      PHPUNIT_VERSION='5.7'
-    elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
-      PHPUNIT_VERSION='4.8'
-    fi
-  fi
-  if [[ ! -z "$PHPUNIT_VERSION" ]]; then
-    mkdir -p $HOME/phpunit-bin/$PHPUNIT_VERSION
-    echo "Opting for phpunit $PHPUNIT_VERSION for PHP $TRAVIS_PHP_VERSION"
-    export PATH="$HOME/phpunit-bin/$PHPUNIT_VERSION:$PATH"
-    if [[ ! -e $HOME/phpunit-bin/$PHPUNIT_VERSION/phpunit ]]; then
-      wget -O $HOME/phpunit-bin/$PHPUNIT_VERSION/phpunit https://phar.phpunit.de/phpunit-$PHPUNIT_VERSION.phar
-      chmod +x $HOME/phpunit-bin/$PHPUNIT_VERSION/phpunit
-    fi
-  fi
-fi
-
 set_environment_variables
 install_tools


### PR DESCRIPTION
Fixes #300 and #267.

- Remove the duplicate PHPUnit version resolver introduced in fc29c35122188d7c98d8949a722498c55b95d040 as a temporary workaround for PHP7 Travis runs.

- Keep the default version of PHPUnit as 5.7 for compatibility reasons.