### PR TITLE
Install pre-commit script should overwrite the file.

### DIFF
--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -40,7 +40,7 @@ if [ -z "$RELPATH" ]; then
 fi
 
 echo "## Placing pre-commit file in $(pwd) from $RELPATH"
-ln -s "$RELPATH" .
+ln -sf "$RELPATH" .
 
 # Return back to the calling directory
 cd "$OLDPWD" &> /dev/null


### PR DESCRIPTION
When running the pre-commit install script from wp-dev-lib, the pre-commit file in .git/hooks should be overwritten, if it exists. Currently, the script just fails and this is troublesome when trying to run the install script on the `post-install-cmd` script for Composer.