### PR TITLE
Download required WP Core asset dependency files

### DIFF
--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -585,6 +585,10 @@ function install_wp {
 	mkdir -p "$WP_CORE_DIR/src/wp-includes/css/dist/block-library"
 	touch "$WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css"
 
+	# Download required asset dependency files
+	local SVN_CORE_URL=$(echo $SVN_URL | sed 's/develop/core/')
+	svn export -q "${SVN_CORE_URL}wp-includes/assets/dist" "$WP_CORE_DIR/src/wp-includes/assets/dist"
+
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/src/wp-content/db.php"
 }
 

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -586,7 +586,7 @@ function install_wp {
 	touch "$WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css"
 
 	# Download required asset dependency files
-	local SVN_CORE_URL=$(echo $SVN_URL | sed 's/develop/core/')
+	local SVN_CORE_URL=${SVN_URL/develop/core}
 	svn export -q "${SVN_CORE_URL}wp-includes/assets/dist" "$WP_CORE_DIR/src/wp-includes/assets/dist"
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/src/wp-content/db.php"

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -581,13 +581,9 @@ function install_wp {
 
 	svn export -q "$SVN_URL" "$WP_CORE_DIR"
 
-	# Add workaround for running PHPUnit tests from source by touching built files.
-	mkdir -p "$WP_CORE_DIR/src/wp-includes/css/dist/block-library"
-	touch "$WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css"
-
-	# Download required asset dependency files
+	# Download `wp-includes` folder from the WordPress Core SVN repo to include built internal dependencies.
 	local SVN_CORE_URL=${SVN_URL/develop/core}
-	svn export -q "${SVN_CORE_URL}wp-includes/assets/dist" "$WP_CORE_DIR/src/wp-includes/assets/dist"
+	svn export -q "${SVN_CORE_URL}wp-includes" "$WP_CORE_DIR/src/wp-includes"
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/src/wp-content/db.php"
 }


### PR DESCRIPTION
As of https://github.com/WordPress/wordpress-develop/commit/a35e46a937436dd28aae36ffea6d2d89abafe8b1, an asset file is now generated for each WordPress JS dependency in Core. This creates a problem when running PHPUnit tests on Travis as these files are not generated during the WordPress setup process (as can be seen [here](https://travis-ci.org/ampproject/amp-wp/jobs/633410009#L985) for example).

This PR resolves this issue by downloading the `wp-includes/assets/dist` folder from WordPress' Core SVN repo during the WordPress installation.