### PR TITLE
Overwrite `wp-includes` directory when installing WordPress

### DIFF
--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -583,7 +583,7 @@ function install_wp {
 
 	# Download `wp-includes` folder from the WordPress Core SVN repo to include built internal dependencies.
 	local SVN_CORE_URL=${SVN_URL/develop/core}
-	svn export -q "${SVN_CORE_URL}wp-includes" "$WP_CORE_DIR/src/wp-includes"
+	svn export -q --force "${SVN_CORE_URL}wp-includes" "$WP_CORE_DIR/src/wp-includes"
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php "$WP_CORE_DIR/src/wp-content/db.php"
 }


### PR DESCRIPTION
Overwrite `wp-includes` folder when downloading from Core SVN repository. This would prevent the error:

> svn: E155000: Destination directory exists; please remove the directory or use --force to overwrite

Relates to #310.