### PR TITLE
Handle multiple eslint config formats

### DIFF
--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -185,7 +185,7 @@ function set_environment_variables {
 	fi
 
 	if [ -z "$ESLINT_CONFIG" ]; then
-		ESLINT_CONFIG="$( upsearch .eslintrc )"
+		ESLINT_CONFIG="$( upsearch .eslintrc* )"
 	fi
 	if [ -z "$ESLINT_IGNORE" ]; then
 		ESLINT_IGNORE="$( upsearch .eslintignore )"
@@ -308,7 +308,7 @@ function set_environment_variables {
 		done
 
 		# Make sure linter configs get copied linting directory since upsearch is relative.
-		for linter_file in .jshintrc .jshintignore .jscsrc .jscs.json .eslintignore .eslintrc .phpcs.xml phpcs.xml .phpcs.xml.dist phpcs.xml.dist phpcs.ruleset.xml ruleset.xml; do
+		for linter_file in .jshintrc .jshintignore .jscsrc .jscs.json .eslintignore .eslintrc .eslintrc.js .eslintrc.json .phpcs.xml phpcs.xml .phpcs.xml.dist phpcs.xml.dist phpcs.ruleset.xml ruleset.xml; do
 			if git ls-files "$linter_file" --error-unmatch > /dev/null 2>&1; then
 				if [ -L $linter_file ]; then
 					ln -fs $(git show :"$linter_file") "$LINTING_DIRECTORY/$linter_file"


### PR DESCRIPTION
Eslint can be configured using `.eslintrc`/`.eslintrc.js`/`.eslintrc.json` file names, so let's handle them