### PR TITLE
Let users supply their own test function

### DIFF
--- a/sample-config/.dev-lib
+++ b/sample-config/.dev-lib
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+function run_tests {
+	# Run your custom checks before the default linters, tests, etc.
+}
+
+function after_wp_install {
+	# Run any customs code before PHPUnit checks, see `check-diff.sh`.
+}

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -48,6 +48,9 @@ lint_js_files
 lint_php_files
 lint_xml_files
 run_qunit
+if [ "$( type -t run_tests )" != '' ]; then
+	run_tests
+fi
 run_phpunit_local
 run_codeception
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -43,7 +43,7 @@ install_tools
 echo "## Checking files, scope $CHECK_SCOPE:"
 cat "$TEMP_DIRECTORY/paths-scope"
 
-# Run any custom checks by defining a run_tests function in .dev-lib, for example.
+# Run any custom checks by defining a run_tests function, see sample-scripts/.dev-lib
 if [ "$( type -t run_tests )" != '' ]; then
 	run_tests
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -43,14 +43,16 @@ install_tools
 echo "## Checking files, scope $CHECK_SCOPE:"
 cat "$TEMP_DIRECTORY/paths-scope"
 
+# Run any custom checks by defining a run_tests function in .dev-lib, for example.
+if [ "$( type -t run_tests )" != '' ]; then
+	run_tests
+fi
+
 check_execute_bit
 lint_js_files
 lint_php_files
 lint_xml_files
 run_qunit
-if [ "$( type -t run_tests )" != '' ]; then
-	run_tests
-fi
 run_phpunit_local
 run_codeception
 

--- a/scripts/travis.script.sh
+++ b/scripts/travis.script.sh
@@ -13,5 +13,8 @@ lint_js_files
 lint_php_files
 lint_xml_files
 run_qunit
+if [ "$( type -t run_tests )" != '' ]; then
+	run_tests
+fi
 run_phpunit_travisci
 run_codeception

--- a/scripts/travis.script.sh
+++ b/scripts/travis.script.sh
@@ -8,13 +8,15 @@ if [[ -z $SKIP_ECHO_PATHS_SCOPE ]] && [[ $CHECK_SCOPE != "all" ]]; then
 fi
 echo
 
+# Run any custom checks by defining a run_tests function, see sample-scripts/.dev-lib
+if [ "$( type -t run_tests )" != '' ]; then
+	run_tests
+fi
+
 check_execute_bit
 lint_js_files
 lint_php_files
 lint_xml_files
 run_qunit
-if [ "$( type -t run_tests )" != '' ]; then
-	run_tests
-fi
 run_phpunit_travisci
 run_codeception


### PR DESCRIPTION
You may want to run a different test suite like Jest, for example. This will make it so you can create a `run_tests` function in `.dev-lib` for convenience.